### PR TITLE
Add contribution documents and guidelines

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,29 @@
+# Participation Guidelines
+
+This guidelines cover our behaviour as contributors, volunteers, vendors, and for anyone else involved in working on Popper.
+
+## How to Treat Each Other
+
+* Try to be respectful and welcoming
+* Try to understand different perspectives
+* Don't threaten violence
+* Empower others to do their best
+* Strive for excellence
+* Don’t expect to agree with every decision by others
+* Do unto others as you would have them do unto you
+
+## Inclusion and Diversity
+
+We welcome and encourage participation by everyone. It doesn’t matter who you are or how others perceive you: we welcome you to help contribute.
+
+We welcome contributions from everyone as long as they interact constructively with our community, including, but not limited to people of varied age, culture, language, gender, etc.
+
+## Raising Issues
+
+If you believe you‘re experiencing practices which don‘t meet our guidelines above, please immediately [email us](mailto:ivo@cs.ucsc.edu).
+
+We reserve the right to refuse contributions from anyone violating the spirit of these policies.
+
+## Working in the Open
+
+Because working open is one of our core values, development on Popper is done in the open on GitHub (check out our repo [here](https://github.com/systemslab/popper)). We hope contributors will benefit from this culture of transparency and collaboration and will work with an open ethos.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,50 @@
+# Contributing to Popper
+
+Thank you for your interest in contributing to Popper :tada:!
+
+This document is a part of a set of guidelines for contributing to Popper on GitHub. These are guidelines, not rules. This guide is meant to make it easy for you to get involved.
+
+We're working with scientists in genomics, weather prediction, playable media, distributed systems (and adding more domains) to have them use DevOps tools and follow software engineering best-practices when they implement experiments associated to academic articles. Our goal is to lower the barriers for collaboration and the sharing of knowledge.
+
+## Participation guidelines
+
+Popper adheres to our code of conduct, [posted in this repository](CODE_OF_CONDUCT.md). By participating or contributing to Popper, you're expected to uphold this code. If you encounter unacceptable behavior, please immediately [email us](mailto:ivo@cs.ucsc.edu).
+
+## What to working on
+
+Take a look at the issues in our [future milestones](https://github.com/systemslab/popper/milestones) or browse some [bugs](https://github.com/systemslab/popper/labels/bug) to get started!
+
+You can also see the work that's being done on various [GitHub issues](https://github.com/systemslab/popper/issues) through [our branches](https://github.com/systemslab/popper/branches).
+
+## How to contribute changes
+
+Once you've identified one of the issues above that you want to contribute to, you're ready to make a change to the project repository!
+ 
+1. **[Fork](https://help.github.com/articles/fork-a-repo/) this repository**. This makes your own version of this project you can edit and use.
+2. **[Make your changes](https://guides.github.com/activities/forking/#making-changes)**! You can do this in the GitHub interface on your own local machine. Once you're happy with your changes...
+3. **Submit a [pull request](https://help.github.com/articles/proposing-changes-to-a-project-with-pull-requests/)**. This opens a discussion around your project and lets the project lead know you are proposing changes.
+
+First time contributing to an open source project? Check out this guide on [how to contribute to an open source project on GitHub](https://egghead.io/series/how-to-contribute-to-an-open-source-project-on-github).
+
+## How to report bugs
+
+We track bugs as [GitHub issues](https://github.com/systemslab/popper/issues). Before posting a bug as a new issue, [please do a search](https://github.com/systemslab/popper/issues?q=is%3Aopen+is%3Aissue+label%3Abug) to see if the bug you're experiencing was already reported by someone else. If it was, add a comment to that issue instead of creating a new one.
+
+### How to submit good bug reports
+
+A more detailed bug report will help people track down and fix your issue faster. Try to include the following in your bug report if you can: 
+
+* Create a detailed title in your report to properly explain your issue
+* Include any screen captures or terminal output if necessary.
+* List what version of Popper you are using.
+* Describe an exact sequence of steps that can reproduce your issue. If you can't reliably replicate your issues, explain what you were doing before the problem happened and how often it happens.
+* Is this a new bug? Include when you started having these issues.
+
+Post any bugs, requests, or questions on the [GitHub issues page for Popper](https://github.com/systemslab/popper/issues)!
+
+## Communication channels
+
+If want to contribute and you're still not certain on how to start please feel
+free to [email us](mailto:ivo@cs.ucsc.edu),
+[chat on Gitter](https://gitter.im/systemslab/popper) or [open an
+issue](https://github.com/systemslab/popper/issues/new).

--- a/README.md
+++ b/README.md
@@ -2,8 +2,11 @@
 
 [![Join the chat at https://gitter.im/systemslab/popper](https://badges.gitter.im/systemslab/popper.svg)](https://gitter.im/falsifiable-us/popper?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge)
 
-Popper is a convention for generating reproducible papers. This 
-repository contains:
+Popper is a convention for generating reproducible papers. We're working with scientists in genomics, weather prediction, playable media, distributed systems (and adding more domains) to have them use DevOps tools and follow software engineering best-practices when they implement experiments associated to academic articles. Our goal is to lower the barriers for collaboration and the sharing of knowledge.
+
+## Getting Started
+
+This repository contains:
 
   * A [CLI tool](popper/) to help bootstrap research articles that 
     adhere to the convention.
@@ -12,9 +15,14 @@ repository contains:
   * [Experiment re-usable templates](templates/) that can be retrieved using the
     CLI tool (or by cloning this repo).
 
-We are currently working with researchers in many scientific domains
-to include more experiments to this repository. If you are interested
-in contributing one but are not certain on how to start, please feel
-free to [email us](mailto:ivo@cs.ucsc.edu),
-[chat](https://gitter.im/systemslab/popper) or [open an
-issue](https://github.com/systemslab/popper/issues/new).
+## Contributing
+
+Anyone is welcome to contribute to Popper! To get started, take a look at [CONTRIBUTING.md](CONTRIBUTING.md).
+
+## Participation Guidelines
+
+Popper adheres to our code of conduct, [posted in this repository](CODE_OF_CONDUCT.md). By participating or contributing to Popper, you're expected to uphold this code. If you encounter unacceptable behavior, please immediately [email us](mailto:ivo@cs.ucsc.edu).
+
+## Hacktoberfest
+
+Join us at [Hacktoberfest](https://hacktoberfest.digitalocean.com/) this month to collaborate on this project and learn from each other.


### PR DESCRIPTION
This PR is based on content provided as part of our involvement in the Mozilla's Open Leaders program and includes the following files:

- An updated README.md file
- CONTRIBUTING.md
- CODE_OF_CONDUCT.md

Most of these files were created using [Mozilla's templates](https://github.com/acabunoc/mozfest-repo-template) for the Open Leaders program and are still pretty barebones, so I'm open to any feedback regarding how to improve them.

This should also resolve systemslab/popper#164.