### PR TITLE
Add asciinema recording of quick start guide

### DIFF
--- a/index.md
+++ b/index.md
@@ -2,7 +2,7 @@
 layout: default
 ---
 
-![]({{ site.baseurl }}/images/popper.gif)
+<script type="text/javascript" src="https://asciinema.org/a/QLBQZeXpz9hTtRQqKhIsQWfZX.js" id="asciicast-QLBQZeXpz9hTtRQqKhIsQWfZX" async></script>
 
 _Popper_ is a convention for conducting experiments and writing 
 academic articles following a 


### PR DESCRIPTION
This commit removes the Popper GIF on the project website and replaces it with a terminal recording of the quickstart guide.

This also closes systemslab/popper#124