### PR TITLE
screencast: fix recording to be compatible with v0.5

### DIFF
--- a/index.md
+++ b/index.md
@@ -2,7 +2,7 @@
 layout: default
 ---
 
-<script type="text/javascript" src="https://asciinema.org/a/QLBQZeXpz9hTtRQqKhIsQWfZX.js" id="asciicast-QLBQZeXpz9hTtRQqKhIsQWfZX" async></script>
+<script src="https://asciinema.org/a/1zxU3oKuAw5LWVh2H1I0dKeAi.js" id="asciicast-1zxU3oKuAw5LWVh2H1I0dKeAi" async></script>
 
 _Popper_ is a convention for conducting experiments and writing 
 academic articles following a 


### PR DESCRIPTION
I updated the screencast for http://falsifiable.us per this comment by @ivotron : https://github.com/systemslab/popper/issues/124#issuecomment-348935239

If everything looks good, the screencast should be updated as soon as this is merged.