### PR TITLE
#221-Single-source version of codebase

### DIFF
--- a/cli/popper/__init__.py
+++ b/cli/popper/__init__.py
@@ -1,0 +1,1 @@
+__version__ = 'Popper 0.6-dev.'

--- a/cli/popper/__init__.py
+++ b/cli/popper/__init__.py
@@ -1,1 +1,1 @@
-__version__ = 'Popper 0.6-dev.'
+__version__ = '0.6-dev.'

--- a/cli/popper/__init__.py
+++ b/cli/popper/__init__.py
@@ -1,1 +1,1 @@
-__version__ = '0.6-dev.'
+__version__ = '0.6-dev'

--- a/cli/popper/cli.py
+++ b/cli/popper/cli.py
@@ -1,7 +1,7 @@
 import os
 import sys
 import click
-import popper
+from . import __version__ as popper_version
 
 class Context(object):
 
@@ -24,7 +24,7 @@ class Context(object):
 pass_context = click.make_pass_decorator(Context, ensure=True)
 cmd_folder = os.path.abspath(os.path.join(os.path.dirname(__file__),
                                           'commands'))
-popper_version = popper.__version__
+popper_version = popper_version
 
 
 class PopperCLI(click.MultiCommand):

--- a/cli/popper/cli.py
+++ b/cli/popper/cli.py
@@ -1,7 +1,7 @@
 import os
 import sys
 import click
-
+import popper
 
 class Context(object):
 
@@ -24,7 +24,7 @@ class Context(object):
 pass_context = click.make_pass_decorator(Context, ensure=True)
 cmd_folder = os.path.abspath(os.path.join(os.path.dirname(__file__),
                                           'commands'))
-popper_version = '0.6-dev'
+popper_version = popper.__version__
 
 
 class PopperCLI(click.MultiCommand):

--- a/cli/popper/commands/cmd_version.py
+++ b/cli/popper/commands/cmd_version.py
@@ -1,11 +1,11 @@
 import click
 import popper.utils as pu
-import popper
-from popper.cli import pass_context
+from .. import __version__ as popper_version
+from ..cli import pass_context
 
 
 @click.command('version', short_help='Show version of Popper and exit.')
 @pass_context
 def cli(ctx):
     """Displays version of Popper and exit."""
-    pu.info(popper.__version__)
+    pu.info(popper_version)

--- a/cli/popper/commands/cmd_version.py
+++ b/cli/popper/commands/cmd_version.py
@@ -1,6 +1,6 @@
 import click
 import popper.utils as pu
-
+import popper
 from popper.cli import pass_context
 
 
@@ -8,4 +8,4 @@ from popper.cli import pass_context
 @pass_context
 def cli(ctx):
     """Displays version of Popper and exit."""
-    pu.info('Popper 0.6-dev.')
+    pu.info(popper.__version__)

--- a/cli/popper/commands/cmd_version.py
+++ b/cli/popper/commands/cmd_version.py
@@ -8,4 +8,4 @@ from ..cli import pass_context
 @pass_context
 def cli(ctx):
     """Displays version of Popper and exit."""
-    pu.info(popper_version)
+    pu.info('popper version ' + popper_version)

--- a/cli/setup.py
+++ b/cli/setup.py
@@ -3,7 +3,7 @@ import popper
 
 version={}
 with open('popper/__init__.py') as f:
-    exec(f.read(),version)
+    exec(f.read(), version)
 
 setup(
     name='popper',

--- a/cli/setup.py
+++ b/cli/setup.py
@@ -1,8 +1,9 @@
 from setuptools import setup
+import popper
 
 setup(
     name='popper',
-    version='0.6-dev0',
+    version='popper.__version__',
     author='The Popper Development Team',
     author_email='ivo@cs.ucsc.edu',
     url='http://falsifiable.us',

--- a/cli/setup.py
+++ b/cli/setup.py
@@ -1,9 +1,13 @@
 from setuptools import setup
 import popper
 
+version={}
+with open('popper/__init__.py') as f:
+    exec(f.read(),version)
+
 setup(
     name='popper',
-    version='popper.__version__',
+    version=version['__version__'],
     author='The Popper Development Team',
     author_email='ivo@cs.ucsc.edu',
     url='http://falsifiable.us',


### PR DESCRIPTION
Currently, there are two sources of the version of the popper CLI, namely the setup.py file and the cmd_version.py. In order to avoid having them be out of sync, they have been single-sourced.

Closes #221 