### PR TITLE
Fixes #235 Add check for .popper.yml integrity

### DIFF
--- a/cli/popper/utils.py
+++ b/cli/popper/utils.py
@@ -54,6 +54,14 @@ def read_config():
 
     with open(config_filename, 'r') as f:
         config = yaml.load(f.read())
+        if not config:
+            fail(".popper.yml is empty. Consider deleting it and "
+                 "reinitializing the repo. See popper init --help for more.")
+        for key in ["metadata", "pipelines"]:
+            if key not in config:
+                fail(".popper.yml doesn't contain expected entries. "
+                     "Consider deleting it and reinitializing the repo. "
+                     "See popper init --help for more.")
 
     return config
 


### PR DESCRIPTION
The read_config() function in utils.py is modified to check if the
.popper.yml file is not empty and if the "metadata" and "pipelines"
dictionaries are defined in it and fail with a proper message if
either criterion is not met.