### PR TITLE
Fixes #228 Add support for providing string timeout values

### DIFF
--- a/cli/popper/commands/cmd_run.py
+++ b/cli/popper/commands/cmd_run.py
@@ -16,10 +16,13 @@ from subprocess import check_output
 @click.argument('pipeline', required=False)
 @click.option(
     '--timeout',
-    help='Timeout limit for pipeline in seconds.',
+    help='Timeout limit for pipeline. Use s for seconds, m for minutes and h '
+         'for hours. A single integer can also be used to specify timeout '
+         'in seconds. Use double quotes if you wish to use more than one unit. '
+         'For example: --timeout "2m 20s" will mean 140 seconds.',
     required=False,
     show_default=True,
-    default=10800
+    default="10800s"
 )
 @click.option(
     '--skip',
@@ -36,6 +39,7 @@ def cli(ctx, pipeline, timeout, skip):
     cwd = os.getcwd()
     pipes = pu.read_config()['pipelines']
     project_root = pu.get_project_root()
+    time_out = pu.parse_timeout(timeout)
 
     if len(pipes) == 0:
         pu.info("No pipelines defined in .popper.yml. Run popper init --help for more info.")
@@ -44,16 +48,16 @@ def cli(ctx, pipeline, timeout, skip):
     if pipeline:
         if pipeline not in pipes:
             pu.fail("Cannot find pipeline {} in .popper.yml".format(pipeline))
-        status = run_pipeline(project_root, pipes[pipeline], timeout, skip)
+        status = run_pipeline(project_root, pipes[pipeline], time_out, skip)
     else:
         if os.path.basename(cwd) in pipes:
             # run just the one for CWD
             status = run_pipeline(project_root, pipes[os.path.basename(cwd)],
-                                  timeout, skip)
+                                  time_out, skip)
         else:
             # run all
             for pipe in pipes:
-                status = run_pipeline(project_root, pipes[pipe], timeout, skip)
+                status = run_pipeline(project_root, pipes[pipe], time_out, skip)
 
                 if status == 'FAIL':
                     break

--- a/cli/popper/utils.py
+++ b/cli/popper/utils.py
@@ -103,3 +103,28 @@ def fail(msg):
 
 def info(msg):
     click.echo(msg)
+
+
+def parse_timeout(timeout):
+    """Takes timeout as string and parses it to obtain the number of seconds.
+    Generates valid error if proper format is not used.
+
+    Returns:
+        Value of timeout in seconds.
+    """
+    time_out = 0
+    to_seconds = {"s": 1, "m": 60, "h": 3600}
+    try:
+        time_out = int(timeout)
+    except ValueError:
+        literals = timeout.split()
+        for literal in literals:
+            unit = literal[-1].lower()
+            value = int(literal[:-1])
+            try:
+                time_out += value * to_seconds[unit];
+            except KeyError:
+                fail("invalid timeout format used. "
+                     "See popper run --help for more.")
+
+    return time_out

--- a/cli/popper/utils.py
+++ b/cli/popper/utils.py
@@ -110,17 +110,21 @@ def parse_timeout(timeout):
     Generates valid error if proper format is not used.
 
     Returns:
-        Value of timeout in seconds.
+        Value of timeout in seconds (float).
     """
     time_out = 0
     to_seconds = {"s": 1, "m": 60, "h": 3600}
     try:
-        time_out = int(timeout)
+        time_out = float(timeout)
     except ValueError:
         literals = timeout.split()
         for literal in literals:
             unit = literal[-1].lower()
-            value = int(literal[:-1])
+            try:
+                value = float(literal[:-1])
+            except ValueError:
+                fail("invalid timeout format used. "
+                     "See popper run --help for more.")
             try:
                 time_out += value * to_seconds[unit];
             except KeyError:

--- a/docs/ci/demo
+++ b/docs/ci/demo
@@ -23,6 +23,13 @@ test -f pipelines/pipeone/post-run.sh
 test -f pipelines/pipeone/validate.sh
 test -f pipelines/pipeone/teardown.sh
 
+# user-friendly timeout values
+popper run --timeout 2.5
+popper run --timeout 10s
+popper run --timeout 0.5m
+popper run --timeout .01h
+popper run --timeout "1m 10s"
+
 # arbitrary stages and envs
 init_test
 popper init --stages=one,two,three --envs=host,ubuntu-xenial pipetwo
@@ -139,4 +146,3 @@ popper env mypipeone | grep 'host'
 #cat wf.dot | grep teardown
 #
 #cd pipelines/pipeone
-


### PR DESCRIPTION
Support for human-friendly timeout values in string format has been added. A function has been added in utils.py which parses the timeout value which can be given as 20s or 10m etc. --timeout option now
takes integer or string as a string and it is converted to seconds accordingly.