### PR TITLE
Fixes #239 Correct stage to stage_file in cmd_run.py

### DIFF
--- a/cli/popper/commands/cmd_run.py
+++ b/cli/popper/commands/cmd_run.py
@@ -95,7 +95,7 @@ def run_pipeline(project_root, pipeline, timeout, skip):
             STATUS = "FAIL"
             pu.info("Logs for {}:.".format(stage))
             for t in ['.err', '.out']:
-                with open('popper_logs/{}{}'.format(stage, t), 'r') as f:
+                with open('popper_logs/{}{}'.format(stage_file, t), 'r') as f:
                     pu.info(f.read())
             break
 


### PR DESCRIPTION
When the popper run command was executed on a pipeline with an invalid stage, python stack traceback was shown for the error where because the code looked for something like validate.err file whereas the file generated is validate.sh.err. This change fixes the error.