### PR TITLE
Fixes #225 Add --ignore-errors flag to 'popper run'

### DIFF
--- a/cli/popper/commands/cmd_run.py
+++ b/cli/popper/commands/cmd_run.py
@@ -54,7 +54,7 @@ def cli(ctx, pipeline, timeout, skip, ignore_errors):
 
     if pipeline:
         if ignore_errors:
-            pu.info("W: ignore-errors flag is ignored when pipeline argument is provided")
+            pu.warn("ignore-errors flag is ignored when pipeline argument is provided")
         if pipeline not in pipes:
             pu.fail("Cannot find pipeline {} in .popper.yml".format(pipeline))
         status = run_pipeline(project_root, pipes[pipeline], time_out, skip)

--- a/cli/popper/commands/cmd_run.py
+++ b/cli/popper/commands/cmd_run.py
@@ -29,8 +29,15 @@ from subprocess import check_output
     help='Comma-separated list of stages to skip.',
     required=False,
 )
+@click.option(
+    '--ignore-errors',
+    is_flag=True,
+    help='Execute all pipelines even if there is a failure, '
+         'only when no pipeline argument is provided ',
+    required=False,
+)
 @pass_context
-def cli(ctx, pipeline, timeout, skip):
+def cli(ctx, pipeline, timeout, skip, ignore_errors):
     """Executes a pipeline and reports its status. When PIPELINE is given, it
     executes only the pipeline with such a name. If the argument is omitted,
     all pipelines are executed in lexicographical order. Reports an error if
@@ -46,6 +53,8 @@ def cli(ctx, pipeline, timeout, skip):
         sys.exit(0)
 
     if pipeline:
+        if ignore_errors:
+            pu.info("W: ignore-errors flag is ignored when pipeline argument is provided")
         if pipeline not in pipes:
             pu.fail("Cannot find pipeline {} in .popper.yml".format(pipeline))
         status = run_pipeline(project_root, pipes[pipeline], time_out, skip)
@@ -59,7 +68,7 @@ def cli(ctx, pipeline, timeout, skip):
             for pipe in pipes:
                 status = run_pipeline(project_root, pipes[pipe], time_out, skip)
 
-                if status == 'FAIL':
+                if status == 'FAIL' and not ignore_errors:
                     break
 
     os.chdir(cwd)
@@ -117,7 +126,8 @@ def run_pipeline(project_root, pipeline, timeout, skip):
         f.write(STATUS + '\n')
 
     pu.info('status : ' + STATUS, fg='green', bold=True)
-    
+    sys.stdout.write('\n')
+
     return STATUS
 
 

--- a/cli/popper/utils.py
+++ b/cli/popper/utils.py
@@ -105,13 +105,19 @@ def fail(msg):
     sys.exit(1)
 
 
+def warn(msg):
+    click.secho('WARNING: ' + msg, fg='orange', bold=True)
+
+
 def info(msg, **styles):
     """Prints the message on the terminal."""
     click.secho(msg, **styles)
 
+
 def print_yaml(msg, **styles):
     """Prints the messages in YAML's block format. """
     click.secho(yaml.dump(msg, default_flow_style = False), **styles)
+
 
 def parse_timeout(timeout):
     """Takes timeout as string and parses it to obtain the number of seconds.


### PR DESCRIPTION
A --ignore-errors flag has been added to the popper run command which executes all pipelines even when there is an error in one (when no pipeline argument is provided) and shows a warning when used while providing a pipeline argument.