### PR TITLE
Adds cmd_stages.py file

### DIFF
--- a/cli/popper/commands/cmd_init.py
+++ b/cli/popper/commands/cmd_init.py
@@ -42,6 +42,7 @@ def cli(ctx, name, stages, envs, existing):
     a folder, which is assumed to contain bash scripts. --stages must be given.
     """
     project_root = pu.get_project_root()
+    stages_list = pu.get_stages(stages)
 
     # init repo
     if name is None:
@@ -55,7 +56,7 @@ def cli(ctx, name, stages, envs, existing):
         # existing pipeline
         abs_path = os.path.join(project_root, name)
         relative_path = name
-        initialize_existing_pipeline(abs_path, stages, envs)
+        initialize_existing_pipeline(abs_path, stages_list, envs)
     elif name == 'paper':
         # create a paper pipeline
         abs_path = os.path.join(project_root, 'paper')
@@ -65,7 +66,7 @@ def cli(ctx, name, stages, envs, existing):
         # new pipeline
         abs_path = os.path.join(project_root, 'pipelines', name)
         relative_path = os.path.join('pipelines', name)
-        initialize_new_pipeline(abs_path, stages, envs)
+        initialize_new_pipeline(abs_path, stages_list, envs)
 
     pu.update_config(name, stages, envs, relative_path)
 
@@ -82,8 +83,8 @@ def initialize_repo(project_root):
     pu.info('Popperized repository ' + project_root, fg='blue', bold=True)
 
 
-def initialize_existing_pipeline(pipeline_path, stages, envs):
-    for s in stages.split(','):
+def initialize_existing_pipeline(pipeline_path, stages_list, envs):
+    for s in stages_list:
         s_filename = os.path.join(pipeline_path, s)
         if not isfile(s_filename) and not isfile(s_filename+'.sh'):
             pu.fail(
@@ -110,7 +111,7 @@ def initialize_paper(paper_path, envs):
     with open(os.path.join(paper_path, 'README',), 'w') as f:
         f.write('# ' + basename(paper_path)+ '\n')
 
-def initialize_new_pipeline(pipeline_path, stages, envs):
+def initialize_new_pipeline(pipeline_path, stages_list, envs):
 
     # create folders
     if isdir(pipeline_path) or isfile(pipeline_path):
@@ -118,7 +119,7 @@ def initialize_new_pipeline(pipeline_path, stages, envs):
     os.makedirs(pipeline_path)
 
     # write stage bash scripts
-    for s in stages.split(','):
+    for s in stages_list:
         if not s.endswith('.sh'):
             s = s + '.sh'
 

--- a/cli/popper/commands/cmd_stages.py
+++ b/cli/popper/commands/cmd_stages.py
@@ -1,5 +1,6 @@
 import click
 import os
+import sys
 import popper.utils as pu
 
 from popper.cli import pass_context
@@ -30,18 +31,20 @@ def cli(ctx, pipeline, set):
 
     if not set:
         pu.print_yaml(str(config['pipelines'][pipeline]['stages']))
+        sys.exit(1)
 
     if set:
-        for s in stages.split(','):
+        stages_list = pu.get_stages(stages)
+        for s in stages_list:
             s_filename = os.path.join(pipeline_path, s)
             if not os.path.isfile(s_filename) and not os.path.isfile(s_filename+'.sh'):
                 pu.fail("Unable to find script for stage " + s +
                 ". You might need to provide values for the --set flag.")
 
-        if 'teardown' in stages and stages.split(',')[-1] != 'teardown' :
+        if 'teardown' in stages and stages_list[-1] != 'teardown' :
             raise BadArgumentUsage('--stages = Teardown should be the last stage.'
         + ' Consider renaming it or putting it at the end.')
 
-        config['pipelines'][pipeline]['stages'] = stages.split(',')
+        config['pipelines'][pipeline]['stages'] = stages_list
 
     pu.write_config(config)

--- a/cli/popper/commands/cmd_stages.py
+++ b/cli/popper/commands/cmd_stages.py
@@ -1,0 +1,47 @@
+import click
+import os
+import popper.utils as pu
+
+from popper.cli import pass_context
+from popper.exceptions import BadArgumentUsage
+
+@click.command('stages', short_help='Comma-separated list of stages to a pipeline')
+@click.argument('pipeline', required=True)
+@click.option(
+    '--set',
+    help="Redefine the stages of a pipeline",
+    required=False
+)
+@pass_context
+def cli(ctx, pipeline, set):
+    """Manipulates the stages of a pipeline.The stages YAML entry specifies
+    the sequence of stages that are executed by the popper check command.When
+    a new pipeline is created, the popper init generates scaffold scripts for
+    setup.sh,run.sh,post-run.sh,validate.sh,teardown.sh by default.(See popper
+    init --help for more)
+
+    Example:
+
+    popper stages #Shows the stages of a pipeline
+
+    popper stages --set=one,two,three #Redefine the stages of a pipeline
+    """
+    config = pu.read_config()
+
+    if not set:
+        pu.print_yaml(str(config['pipelines'][pipeline]['stages']))
+
+    if set:
+        for s in stages.split(','):
+            s_filename = os.path.join(pipeline_path, s)
+            if not os.path.isfile(s_filename) and not os.path.isfile(s_filename+'.sh'):
+                pu.fail("Unable to find script for stage " + s +
+                ". You might need to provide values for the --set flag.")
+
+        if 'teardown' in stages and stages.split(',')[-1] != 'teardown' :
+            raise BadArgumentUsage('--stages = Teardown should be the last stage.'
+        + ' Consider renaming it or putting it at the end.')
+
+        config['pipelines'][pipeline]['stages'] = stages.split(',')
+
+    pu.write_config(config)

--- a/cli/popper/utils.py
+++ b/cli/popper/utils.py
@@ -39,6 +39,8 @@ def get_project_root():
         "Unable to find the root of your project. Initialize repository first."
     )
 
+def get_stages(stages):
+    return(stages.split(','))
 
 def read_config():
     """Reads config from .popper.yml file.


### PR DESCRIPTION
Adds a popper stages command that displays the stages defined in the
.popper.yml file.Also adds a --set flag which redefines the stages of an
existing pipeline.

Fixes https://github.com/systemslab/popper/issues/229