### PR TITLE
Fixes #227 Implement convention of always running 'teardown.sh'

### DIFF
--- a/cli/popper/commands/cmd_run.py
+++ b/cli/popper/commands/cmd_run.py
@@ -129,7 +129,7 @@ def run_pipeline(project_root, pipeline, timeout, skip):
                     stage != 'teardown' and
                     'teardown' in pipeline['stages'] and
                     'teardown' not in skipped):
-                    execute(pu.get_filename(abs_path, 'teardown'), timeout)
+                        execute(pu.get_filename(abs_path, 'teardown'), timeout)
 
                 break
 

--- a/cli/popper/utils.py
+++ b/cli/popper/utils.py
@@ -3,6 +3,7 @@ import os
 import sys
 import yaml
 
+
 def get_path_to_config():
     """Obtains the path to the config file.
 
@@ -88,7 +89,7 @@ def update_config(name, stages, envs, relative_path):
     """Updates the configuration for a pipeline"""
 
     if name == 'paper':
-        stages='build'
+        stages = 'build'
 
     config = read_config()
     config['pipelines'][name] = {
@@ -127,7 +128,7 @@ def info(msg, **styles):
 
 def print_yaml(msg, **styles):
     """Prints the messages in YAML's block format. """
-    click.secho(yaml.dump(msg, default_flow_style = False), **styles)
+    click.secho(yaml.dump(msg, default_flow_style=False), **styles)
 
 
 def parse_timeout(timeout):
@@ -151,7 +152,7 @@ def parse_timeout(timeout):
                 fail("invalid timeout format used. "
                      "See popper run --help for more.")
             try:
-                time_out += value * to_seconds[unit];
+                time_out += value * to_seconds[unit]
             except KeyError:
                 fail("invalid timeout format used. "
                      "See popper run --help for more.")

--- a/cli/popper/utils.py
+++ b/cli/popper/utils.py
@@ -99,6 +99,17 @@ def update_config(name, stages, envs, relative_path):
     write_config(config)
 
 
+def get_filename(abs_path, stage):
+    """Returns filename for a stage"""
+    os.chdir(abs_path)
+    if os.path.isfile(stage):
+        return stage
+    elif os.path.isfile(stage + '.sh'):
+        return stage + '.sh'
+    else:
+        return None
+
+
 def fail(msg):
     """Prints the error message on the terminal."""
     click.secho('ERROR: ' + msg, fg='red', blink=True, bold=True)


### PR DESCRIPTION
- A get_filename method has been added to utils.py for getting the filename of a stage.
- When a stage fails, teardown.sh runs if present and if not skipped.