### PR TITLE
Check python version to load pyyaml appropriately

### DIFF
--- a/cli/bin/popper
+++ b/cli/bin/popper
@@ -7,7 +7,12 @@ cwd = os.path.dirname(os.path.realpath(__file__))
 parentdir = os.path.dirname(cwd)
 vendordir = os.path.join(cwd, 'vendor')
 
-sys.path.insert(0, os.path.join(vendordir, 'pyyaml', 'lib'))
+# Handle vendoring of YAML specially, as it has two versions.
+if sys.version_info[0] == 2:
+    yaml_lib = os.path.join(vendordir, 'pyyaml', 'lib')
+else:
+    yaml_lib = os.path.join(vendordir, 'pyyaml', 'lib3')
+sys.path.insert(0, yaml_lib)
 sys.path.insert(0, os.path.join(vendordir, 'click'))
 sys.path.insert(0, os.path.join(parentdir))
 


### PR DESCRIPTION
pyyaml has two separate libs for python2 and python3 and we need
to specifically load the particular lib for popper to work
correctly with both python2 and python3.

First step towards #271.