### PR TITLE
Change color of warning from orange to magenta

### DIFF
--- a/cli/popper/utils.py
+++ b/cli/popper/utils.py
@@ -118,7 +118,7 @@ def fail(msg):
 
 
 def warn(msg):
-    click.secho('WARNING: ' + msg, fg='orange', bold=True)
+    click.secho('WARNING: ' + msg, fg='magenta', bold=True)
 
 
 def info(msg, **styles):


### PR DESCRIPTION
An error had crept up in PR #244 because orange color used for warnings is no ANSI color and hence the warn utility method won't function correctly. Changing 'orange' to 'magenta' does the job.