### PR TITLE
Fixes #248 Implement a popper add sub-command

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -4,3 +4,6 @@
 [submodule "cli/bin/vendor/click"]
 	path = cli/bin/vendor/click
 	url = https://github.com/pallets/click/
+[submodule "cli/bin/vendor/requests"]
+	path = cli/bin/vendor/requests
+	url = https://github.com/requests/requests/

--- a/cli/popper/commands/cmd_add.py
+++ b/cli/popper/commands/cmd_add.py
@@ -1,0 +1,107 @@
+#!/usr/bin/env python
+
+import click
+import os
+import requests
+import popper.utils as pu
+
+from io import BytesIO
+from popper.cli import pass_context
+
+
+@click.command(
+    'add',
+    short_help='Add a pipeline from popperized repositories on github.'
+)
+@click.argument('pipeline', required=True)
+@pass_context
+def cli(ctx, pipeline):
+    """Add a pipeline to your repository from the existing popperized
+    repositories on github. The pipeline argument is provided as owner/repo/
+    pipeline. For example, popper add popperized/quiho-popper/single-node
+    adds the single-node pipeline from the quiho-popper repository.
+    """
+    try:
+        owner, repo, pipeline_name = pipeline.split('/')
+    except ValueError:
+        pu.fail("See popper add --help for more info.")
+
+    project_root = pu.get_project_root()
+    path = os.path.join(project_root, 'pipelines')
+    dirname = pipeline_name
+    url = ('https://api.github.com/repos/{}/{}/contents/pipelines/{}'
+           .format(owner, repo, pipeline_name))
+
+    save_directory(path, dirname, url)
+    path = os.path.join(path, pipeline_name)
+    update_config(pipeline_name, path)
+    pu.info("Pipeline {} successfully added.".format(pipeline_name),
+            fg="white")
+
+
+def save_file(path, filename, download_url):
+    """Helper method to save a file.
+    """
+    os.chdir(path)
+    r = requests.get(download_url)
+    if r.status_code != 200:
+        pu.fail("Could not download the file {}. Make sure the file "
+                "exists in the pipeline and try again.".format(filename))
+    with open(filename, 'wb') as f:
+        f.writelines(BytesIO(r.content))
+
+
+def save_directory(path, dirname, url):
+    """Recursive method to handle directory download. Creates the empty
+    directory, saves the files that belong to that directory and then calls
+    itself for other directories in that directory.
+    """
+    r = requests.get(url)
+    if r.status_code != 200:
+        pu.fail("Could not download the directory {}. Make sure the directory "
+                "exists in the pipeline and try again.".format(dirname))
+
+    os.chdir(path)
+    try:
+        os.mkdir(dirname)
+    except FileExistsError:
+        pass
+    path = os.path.join(path, dirname)
+
+    response = r.json()
+    for item in response:
+        if item['type'] == 'file':
+            filename = item['name']
+            download_url = item['download_url']
+            filepath = item['path']
+            pu.info("Saving file {} to {}".format(filename, filepath))
+            save_file(path, filename, download_url)
+        else:
+            dirname = item['name']
+            url = item['url']
+            dirpath = item['path']
+            pu.info("Saving directory {} to {}".format(dirname, dirpath))
+            save_directory(path, dirname, url)
+
+
+def update_config(pipeline_name, path):
+    """Adds the metadata for the pipeline to the .popper.yml file.
+    """
+    config_envs = ['host']
+    config_path = 'pipelines/{}'.format(pipeline_name)
+    config_stages = ['setup', 'run', 'post-run', 'validate', 'teardown']
+    to_remove = []
+    files_list = os.listdir(path)
+
+    for stage in config_stages:
+        if stage not in files_list and stage + '.sh' not in files_list:
+            to_remove.append(stage)
+    config_stages = list(filter(lambda x: x not in to_remove, config_stages))
+
+    config = pu.read_config()
+    config['pipelines'][pipeline_name] = {
+        'envs': config_envs,
+        'path': config_path,
+        'stages': config_stages
+    }
+    pu.write_config(config)

--- a/cli/setup.py
+++ b/cli/setup.py
@@ -19,7 +19,8 @@ setup(
     include_package_data=True,
     install_requires=[
         'click',
-        'pyyaml'
+        'pyyaml',
+        'requests'
     ],
     entry_points='''
         [console_scripts]

--- a/docs/ci/demo
+++ b/docs/ci/demo
@@ -142,6 +142,44 @@ popper env mypipeone | grep 'baz'
 popper env mypipeone --rm foo,bar,baz
 popper env mypipeone | grep 'host'
 
+# popper add
+popper add popperized/quiho-popper/single-node
+test -d pipelines/single-node
+test -f pipelines/single-node/datapackage/quiho/datapackage.json
+test -f pipelines/single-node/datapackage/quiho/machines.csv
+test -f pipelines/single-node/datapackage/quiho/results.csv
+test -f pipelines/single-node/geni/release.py
+test -f pipelines/single-node/geni/request.py
+test -f pipelines/single-node/setup/cloudlab.sh
+test -f pipelines/single-node/setup/travis.sh
+test -f pipelines/single-node/results/postprocess.sh
+test -f pipelines/single-node/results/visualize.ipynb
+test -f pipelines/single-node/results/visualize.sh
+test -f pipelines/single-node/results/figures/apps_variability.pdf
+test -f pipelines/single-node/results/figures/mariadb-innodb-vs-memory.pdf
+test -f pipelines/single-node/results/figures/corrmatrix.pdf
+test -f pipelines/single-node/results/figures/pca-var-reduction.pdf
+test -f pipelines/single-node/results/figures/corrmatrix_underfit.pdf
+test -f pipelines/single-node/results/figures/redis-set_underfit.pdf
+test -f pipelines/single-node/results/figures/four.pdf
+test -f pipelines/single-node/results/figures/stream-nadds-behavior.pdf
+test -f pipelines/single-node/results/figures/hpccg.pdf
+test -f pipelines/single-node/results/figures/stream-nadds.pdf
+test -f pipelines/single-node/results/figures/mariadb-innodb-regression.pdf
+test -f pipelines/single-node/results/figures/stressng_variability.pdf
+test -f pipelines/single-node/results/previous/2017-06-07T0501.tgz
+test -f pipelines/single-node/results/previous/20170821-120356-88f97bd.tgz
+test -f pipelines/single-node/results/previous/2017-06-07T0502.tgz
+test -f pipelines/single-node/results/previous/2017-10-20-mysql-regression.tgz
+test -f pipelines/single-node/results/previous/2017-06-07T0503.tgz
+test -f pipelines/single-node/run.sh
+test -f pipelines/single-node/teardown.sh
+test -f pipelines/single-node/wf.png
+test -f pipelines/single-node/post-run.sh
+test -f pipelines/single-node/validate.sh
+test -f pipelines/single-node/setup.sh
+test -f pipelines/single-node/vars.yml
+
 # TODO
 
 #popper ci circleci


### PR DESCRIPTION
A new sub-command add is added which adds a pipeline to the repo from existing popperized repositories on github and also updates the .popper.yml as required.