### PR TITLE
Fixes #256 Add a popper cleanup sub-command

### DIFF
--- a/cli/popper/commands/cmd_cleanup.py
+++ b/cli/popper/commands/cmd_cleanup.py
@@ -20,9 +20,9 @@ def cli(ctx):
     pipelines = {}
 
     for pipeline in os.listdir(pipeline_dir):
-        envs =  popper_config['pipelines'][pipeline]['envs']
-        relative_path =  popper_config['pipelines'][pipeline]['path']
-        defined_stages =  popper_config['pipelines'][pipeline]['stages']
+        envs = popper_config['pipelines'][pipeline]['envs']
+        relative_path = popper_config['pipelines'][pipeline]['path']
+        defined_stages = popper_config['pipelines'][pipeline]['stages']
         existing_stages = []
         for stage in defined_stages:
             os.chdir(os.path.join(pipeline_dir, pipeline))
@@ -38,4 +38,4 @@ def cli(ctx):
     pu.write_config(popper_config)
 
     pu.info("\nYour popper.yml file has been updated! Run git diff to see "
-            "the differences", fg="white")
+            "the differences.", fg="white")

--- a/cli/popper/commands/cmd_cleanup.py
+++ b/cli/popper/commands/cmd_cleanup.py
@@ -1,0 +1,40 @@
+#!/usr/bin/env python
+
+import click
+import os
+import popper.utils as pu
+
+from popper.cli import pass_context
+
+
+@click.command(
+    'cleanup', short_help='Synchronize your pipelines and popper.yml file.'
+)
+@pass_context
+def cli(ctx):
+    """Synchronize your pipelines and popper.yml file if you have
+    deleted anypipeline or stage.
+    """
+    pipeline_dir = os.path.join(pu.get_project_root(), 'pipelines')
+    popper_config = pu.read_config()
+    pipelines = {}
+
+    for pipeline in os.listdir(pipeline_dir):
+        envs =  popper_config['pipelines'][pipeline]['envs']
+        relative_path =  popper_config['pipelines'][pipeline]['path']
+        defined_stages =  popper_config['pipelines'][pipeline]['stages']
+        existing_stages = []
+        for stage in defined_stages:
+            os.chdir(os.path.join(pipeline_dir, pipeline))
+            if os.path.exists(stage+'.sh') or os.path.exists(stage):
+                existing_stages.append(stage)
+        pipelines[pipeline] = {
+            'envs': envs,
+            'path': relative_path,
+            'stages': existing_stages
+        }
+
+    popper_config['pipelines'] = pipelines
+    pu.write_config(popper_config)
+
+    pu.info("\nYour popper.yml file has been updated!", fg="white")

--- a/cli/popper/commands/cmd_cleanup.py
+++ b/cli/popper/commands/cmd_cleanup.py
@@ -12,8 +12,8 @@ from popper.cli import pass_context
 )
 @pass_context
 def cli(ctx):
-    """Synchronize your pipelines and popper.yml file if you have
-    deleted anypipeline or stage.
+    """Synchronize your pipelines and popper.yml file if any pipeline or stage
+    has been deleted.
     """
     pipeline_dir = os.path.join(pu.get_project_root(), 'pipelines')
     popper_config = pu.read_config()
@@ -37,4 +37,5 @@ def cli(ctx):
     popper_config['pipelines'] = pipelines
     pu.write_config(popper_config)
 
-    pu.info("\nYour popper.yml file has been updated!", fg="white")
+    pu.info("\nYour popper.yml file has been updated! Run git diff to see "
+            "the differences", fg="white")

--- a/docs/ci/demo
+++ b/docs/ci/demo
@@ -211,6 +211,15 @@ test -f pipelines/single-node/validate.sh
 test -f pipelines/single-node/setup.sh
 test -f pipelines/single-node/vars.yml
 
+
+rm -rf pipelines/single-node
+popper stages mypipeone | grep teardown
+popper stages mypipeone | grep post-run
+popper cleanup
+! cat .popper.yml | grep 'single-node'
+! popper stages mypipeone | grep teardown
+! popper stages mypipeone | grep post-run
+
 # TODO
 
 #popper ci circleci

--- a/docs/ci/demo
+++ b/docs/ci/demo
@@ -211,14 +211,20 @@ test -f pipelines/single-node/validate.sh
 test -f pipelines/single-node/setup.sh
 test -f pipelines/single-node/vars.yml
 
-
-rm -rf pipelines/single-node
-popper stages mypipeone | grep teardown
-popper stages mypipeone | grep post-run
+# cleanup command
+init_test
+popper init mypipetwo
+popper init mypipethree
+rm pipelines/mypipetwo/teardown.sh
+rm pipelines/mypipetwo/post-run.sh
+rm -rf pipelines/mypipethree
+cat .popper.yml | grep mypipethree
+popper stages mypipetwo | grep teardown
+popper stages mypipetwo | grep post-run
 popper cleanup
-! cat .popper.yml | grep 'single-node'
-! popper stages mypipeone | grep teardown
-! popper stages mypipeone | grep post-run
+! cat .popper.yml | grep mypipethree
+! popper stages mypipetwo | grep teardown
+! popper stages mypipetwo | grep post-run
 
 # TODO
 


### PR DESCRIPTION
When a pipeline folder is deleted, its definition stays in the .popper.yml file. This sub-command will ensure that the pipelines folder and the .popper.yml are in sync.