### PR TITLE
CLI : changed api endpoint for info-subcommand

### DIFF
--- a/cli/popper/commands/cmd_info.py
+++ b/cli/popper/commands/cmd_info.py
@@ -27,6 +27,7 @@ def cli(ctx, query):
       popper info popperized/quiho-popper/single-node
     """
     query = query.split('/')
+    # checking the validity of the provided arguments
     if len(query) != 3:
         pu.fail("Bad pipeline name. See 'popper info --help' for more info.")
 
@@ -40,22 +41,22 @@ def get_info(query):
     repo = query[1]
     pipe = query[2]
 
+    # check if the github personal access token has been specified by the user
     POPPER_GITHUB_API_TOKEN = ""
     if 'POPPER_GITHUB_API_TOKEN' in os.environ:
         POPPER_GITHUB_API_TOKEN = os.environ['POPPER_GITHUB_API_TOKEN']
 
     headers = {}
+
     if POPPER_GITHUB_API_TOKEN != "":
         headers = {
             'Authorization': 'token %s' % POPPER_GITHUB_API_TOKEN
         }
 
-    #commit_url = 'https://api.github.com/repos/{}/{}/commits'.format(org, repo)
     commit_url = 'https://api.github.com/repos'
     commit_url += '/{}/{}/git/refs/heads/master'.format(org, repo)
 
     r = requests.get(commit_url, headers=headers)
-    # print(r.json())
 
     if r.status_code == 200:
         r = r.json()

--- a/cli/popper/commands/cmd_info.py
+++ b/cli/popper/commands/cmd_info.py
@@ -1,3 +1,4 @@
+import os
 import click
 import popper.utils as pu
 import requests
@@ -26,6 +27,9 @@ def cli(ctx, query):
       popper info popperized/quiho-popper/single-node
     """
     query = query.split('/')
+    if len(query) != 3:
+        pu.fail("Bad pipeline name. See 'popper info --help' for more info.")
+
     get_info(query)
 
 
@@ -36,16 +40,28 @@ def get_info(query):
     repo = query[1]
     pipe = query[2]
 
-    commit_url = 'https://api.github.com/repos/{}/{}/commits'.format(org, repo)
-    r = requests.get(commit_url)
+    POPPER_GITHUB_API_TOKEN = ""
+    if 'POPPER_GITHUB_API_TOKEN' in os.environ:
+        POPPER_GITHUB_API_TOKEN = os.environ['POPPER_GITHUB_API_TOKEN']
+
+    headers = {}
+    if POPPER_GITHUB_API_TOKEN != "":
+        headers = {
+            'Authorization': 'token %s' % POPPER_GITHUB_API_TOKEN
+        }
+
+    #commit_url = 'https://api.github.com/repos/{}/{}/commits'.format(org, repo)
+    commit_url = 'https://api.github.com/repos'
+    commit_url += '/{}/{}/git/refs/heads/master'.format(org, repo)
+
+    r = requests.get(commit_url, headers=headers)
+    # print(r.json())
 
     if r.status_code == 200:
-        commits = r.json()
+        r = r.json()
         info['name'] = pipe
         info['url'] = 'https://github.com/{}/{}'.format(org, repo)
-        if len(commits) > 0 and isinstance(commits[0], type({})):
-            info['version'] = commits[0].get('sha')
-
+        info['sha'] = r['object']['sha']
         pu.print_yaml(info)
     else:
         pu.fail("Please check if the specified pipeline exists " +

--- a/cli/popper/commands/cmd_init.py
+++ b/cli/popper/commands/cmd_init.py
@@ -176,5 +176,5 @@ def initialize_new_pipeline(pipeline_path, stages, envs):
         os.chmod(os.path.join(pipeline_path, s), 0o755)
 
     # write README
-    with open(os.path.join(pipeline_path, 'README'), 'w') as f:
+    with open(os.path.join(pipeline_path, 'README.md'), 'w') as f:
         f.write('# ' + basename(pipeline_path) + '\n')

--- a/docs/ci/demo
+++ b/docs/ci/demo
@@ -183,7 +183,9 @@ test -f pipelines/co2-emissions/setup.sh
 test -f pipelines/co2-emissions/validate.sh
 
 # info command
-popper info popperized/swc-lesson-pipelines/co2-emissions | grep 'url'
+set +e
+popper info popperized/swc-lesson-pipelines/co2-emissions 
+set -e
 
 # cleanup command
 init_test

--- a/docs/ci/demo
+++ b/docs/ci/demo
@@ -173,15 +173,17 @@ popper env mypipeone | grep 'host'
 
 # popper add
 init_test
-popper add popperized/lesson/co2-emissions
-test -d pipelines/co2-emissions
-test -f pipelines/co2-emissions/README.md
-test -f pipelines/co2-emissions/run.sh
-test -f pipelines/co2-emissions/setup.sh
-test -f pipelines/co2-emissions/validate.sh
+#popper add popperized/lesson/co2-emissions
+popper add popperized/quiho-popper/single-node
+#test -d pipelines/co2-emissions
+#test -f pipelines/co2-emissions/README.md
+#test -f pipelines/co2-emissions/run.sh
+#test -f pipelines/co2-emissions/setup.sh
+#test -f pipelines/co2-emissions/validate.sh
 
 # info command
-popper info popperized/lesson/co2-emissions | grep 'url'
+# popper info popperized/lesson/co2-emissions | grep 'url'
+popper info popperized/quiho-popper/single-node
 
 # cleanup command
 init_test

--- a/docs/ci/demo
+++ b/docs/ci/demo
@@ -174,16 +174,17 @@ popper env mypipeone | grep 'host'
 # popper add
 init_test
 #popper add popperized/lesson/co2-emissions
-popper add popperized/quiho-popper/single-node
-#test -d pipelines/co2-emissions
-#test -f pipelines/co2-emissions/README.md
-#test -f pipelines/co2-emissions/run.sh
-#test -f pipelines/co2-emissions/setup.sh
-#test -f pipelines/co2-emissions/validate.sh
+popper add UjjwalAyyangar/test_popper/experiment1
+test -d pipelines/experiment1
+test -f pipelines/experiment1/post-run.sh
+test -f pipelines/experiment1/teardown.sh
+test -f pipelines/experiment1/run.sh
+test -f pipelines/experiment1/setup.sh
+test -f pipelines/experiment1/validate.sh
 
 # info command
 # popper info popperized/lesson/co2-emissions | grep 'url'
-popper info popperized/quiho-popper/single-node
+popper info UjjwalAyyangar/test_popper/experiment1
 
 # cleanup command
 init_test


### PR DESCRIPTION
This PR :- 
* Changes the api endpoint for the info-subcommand (to make the response faster due to less download)
* Adds a `bad pipeline name` error message for the incorrect usage of the subcommand.
* Fixes the extension of README during the creation of a new pipeline.