### PR TITLE
[Docs] Fix help command in "getting started" and link to software carpentry lesson

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ Quick links to other resources:
   * [5-minute screencast demo of the CLI](https://asciinema.org/a/xzEYfI3U4H5CWdmjBe0O2CAw8).
   * [Slidedeck introducing the convention](https://www.slideshare.net/ivotron/the-popper-experimentation-protocol-and-cli-tool-86987253).
   * [10-min video recording of intro and demo](https://air.mozilla.org/mozilla-open-leaders-round-4-final-demos-open-succulent-project/#@52m0s).
-  * [Software Carpentry formatted Lesson](https://ivotron.github.io/popper-lesson).
+  * [Software Carpentry formatted Lesson](https://popperized.github.io/swc-lesson/).
   * [List of repositories that follow the convention](https://github.com/popperized).
 
 ## Installation

--- a/docs/protocol/getting_started.md
+++ b/docs/protocol/getting_started.md
@@ -10,7 +10,7 @@ instructions](https://github.com/systemslab/popper/tree/master/cli#install).
 Show the available commands:
 
 ```bash
-popper help
+popper --help
 ```
 
 Show which version you installed:


### PR DESCRIPTION
- `popper help` doesn't work, I guess it should be `popper --help` instead
- fix link to carpentry-style lesson