### PR TITLE
CLI : Changes api endpoint for the info subcommand

### DIFF
--- a/cli/popper/commands/cmd_info.py
+++ b/cli/popper/commands/cmd_info.py
@@ -1,3 +1,4 @@
+import os
 import click
 import popper.utils as pu
 import requests
@@ -26,6 +27,10 @@ def cli(ctx, query):
       popper info popperized/quiho-popper/single-node
     """
     query = query.split('/')
+    # checking the validity of the provided arguments
+    if len(query) != 3:
+        pu.fail("Bad pipeline name. See 'popper info --help' for more info.")
+
     get_info(query)
 
 
@@ -36,16 +41,28 @@ def get_info(query):
     repo = query[1]
     pipe = query[2]
 
-    commit_url = 'https://api.github.com/repos/{}/{}/commits'.format(org, repo)
-    r = requests.get(commit_url)
+    # check if the github personal access token has been specified by the user
+    POPPER_GITHUB_API_TOKEN = ""
+    if 'POPPER_GITHUB_API_TOKEN' in os.environ:
+        POPPER_GITHUB_API_TOKEN = os.environ['POPPER_GITHUB_API_TOKEN']
+
+    headers = {}
+
+    if POPPER_GITHUB_API_TOKEN != "":
+        headers = {
+            'Authorization': 'token %s' % POPPER_GITHUB_API_TOKEN
+        }
+
+    commit_url = 'https://api.github.com/repos'
+    commit_url += '/{}/{}/git/refs/heads/master'.format(org, repo)
+
+    r = requests.get(commit_url, headers=headers)
 
     if r.status_code == 200:
-        commits = r.json()
+        r = r.json()
         info['name'] = pipe
         info['url'] = 'https://github.com/{}/{}'.format(org, repo)
-        if len(commits) > 0 and isinstance(commits[0], type({})):
-            info['version'] = commits[0].get('sha')
-
+        info['sha'] = r['object']['sha']
         pu.print_yaml(info)
     else:
         pu.fail("Please check if the specified pipeline exists " +

--- a/cli/popper/commands/cmd_init.py
+++ b/cli/popper/commands/cmd_init.py
@@ -176,5 +176,5 @@ def initialize_new_pipeline(pipeline_path, stages, envs):
         os.chmod(os.path.join(pipeline_path, s), 0o755)
 
     # write README
-    with open(os.path.join(pipeline_path, 'README'), 'w') as f:
+    with open(os.path.join(pipeline_path, 'README.md'), 'w') as f:
         f.write('# ' + basename(pipeline_path) + '\n')


### PR DESCRIPTION
This PR :- 
* Changes the api endpoint for the info-subcommand (to make the response faster due to less download)
* Adds a `bad pipeline name` error message for the incorrect usage of the subcommand.
* Fixes the extension of README during the creation of a new pipeline.