### PR TITLE
Fixes #342 Create new record for separate repository

### DIFF
--- a/docs/ci/demo
+++ b/docs/ci/demo
@@ -218,7 +218,8 @@ popper metadata --add title='Popper test archive'
 popper metadata --add author1='Test Author, testauthor@gmail.com, popper'
 popper metadata --add abstract='A short description of the article'
 popper metadata --add keywords='comma, separated, keywords'
-#popper archive --service zenodo
+git remote add origin https://github.com/systemslab/popper-test.git
+popper archive --service zenodo
 popper metadata --add categories='1656'
 popper archive --service figshare
 

--- a/docs/ci/demo
+++ b/docs/ci/demo
@@ -213,14 +213,18 @@ popper cleanup
 # archive command test
 init_test
 popper init archive_pipe
+git config --global user.email "testuser@example.com"
+git config --global user.name "Test User"
 echo "echo \"Today's date is: $(date +"%Y%m%d-%H%M%S")\"" >> pipelines/archive_pipe/post-run.sh
 popper metadata --add title='Popper test archive'
 popper metadata --add author1='Test Author, testauthor@gmail.com, popper'
 popper metadata --add abstract='A short description of the article'
 popper metadata --add keywords='comma, separated, keywords'
 git remote add origin https://github.com/systemslab/popper-test.git
+git add . && git commit -m "Add metadata"
 popper archive --service zenodo
 popper metadata --add categories='1656'
+git add . && git commit -m "Modify metadata"
 popper archive --service figshare
 
 # test popper rm command


### PR DESCRIPTION
When popper archive is run on new repository which has not been archived yet, a new record is created otherwise, a new version of a previously existing record is created. Also enabled test for popper archive with zenodo and fixed the tests.