### PR TITLE
Fixes #332. Add popper matrix subcommand

### DIFF
--- a/cli/popper/commands/cmd_matrix.py
+++ b/cli/popper/commands/cmd_matrix.py
@@ -1,0 +1,58 @@
+import click
+import popper.utils as pu
+
+from popper.cli import pass_context
+from popper.exceptions import BadArgumentUsage
+
+
+@click.command('matrix', short_help='Define execution matrix for a '
+               'pipeline using environment variables.')
+@click.argument('pipeline', required=True)
+@click.option(
+    '--add',
+    multiple=True,
+    help='Add environment variable in the form key=value',
+    required=False
+)
+@click.option(
+    '--rm',
+    multiple=True,
+    help='Remove environment variable using the key',
+    required=False
+)
+@pass_context
+def cli(ctx, pipeline, add, rm):
+    try:
+        config = pu.read_config()
+        pipeline_config = config['pipelines'][pipeline]
+    except KeyError:
+        raise BadArgumentUsage("Pipeline {} does not exist.".format(pipeline))
+    if not add and not rm:
+        try:
+            pu.print_yaml(pipeline_config['matrix']['vars'])
+        except KeyError:
+            pu.info("No environment variables defined for this pipeline.")
+    if add:
+        try:
+            matrix = pipeline_config['matrix']
+        except KeyError:
+            matrix = {'vars': {}}
+        for var in add:
+            key, val = var.split('=')
+            matrix['vars'][key] = val
+        config['pipelines'][pipeline]['matrix'] = matrix
+        pu.write_config(config)
+    if rm:
+        try:
+            matrix = pipeline_config['matrix']
+        except KeyError:
+            pu.fail("No environment variables defined for this pipeline.")
+
+        for key in rm:
+            try:
+                del matrix['vars'][key]
+            except KeyError:
+                raise BadArgumentUsage("Environment variable {} does not "
+                                       "exist in the matrix".format(key))
+        config['pipelines'][pipeline]['matrix'] = matrix
+        pu.write_config(config)

--- a/docs/ci/demo
+++ b/docs/ci/demo
@@ -210,6 +210,15 @@ popper cleanup
 ! popper stages mypipetwo | grep teardown
 ! popper stages mypipetwo | grep post-run
 
+# popper matrix subcommand
+init_test
+popper init mypipeone
+popper matrix mypipeone --add key1=val1 --add key2=val2
+popper matrix mypipeone | grep -q key1
+popper matrix mypipeone | grep -q key2
+popper matrix mypipeone --rm key1
+! popper matrix mypipeone | grep -q key1
+
 # test popper rm command
 init_test
 popper init mypipetwo


### PR DESCRIPTION
popper matrix subcommand can be used to define an execution matrix for a pipeline using environment variables. It is used as `popper matrix pipeline --add key1=val1` to add a key and `popper matrix pipeline --rm key1` to remove a key.