### PR TITLE
Fix 'parameters --add' documentation.

### DIFF
--- a/docs/sections/ci_features.md
+++ b/docs/sections/ci_features.md
@@ -201,7 +201,7 @@ of environment variables. For example, if a pipeline takes parameters
 `par1` and `par2`, the following can specify these:
 
 ```
-popper parameters my-pipe --add 'par1=val1 par2=val2'
+popper parameters my-pipe --add par1=val1 --add par2=val2
 ```
 
 This will cause the `.popper.yml` to look like the following:
@@ -223,7 +223,7 @@ where each item in the dictionary is an environment variable. A
 subsequent set of parameters can be added:
 
 ```
-popper parameters my-pipe --add 'par1=val3 par2=val4'
+popper parameters my-pipe --add par1=val3 --add par2=val4
 ```
 
 Which will result in the following:


### PR DESCRIPTION
Fix problem described in issue #476, in which the documentation does not describe the proper method to add multiple parameters.