### PR TITLE
Fixes #518 Typo fixes in setup.py

### DIFF
--- a/cli/setup.py
+++ b/cli/setup.py
@@ -17,7 +17,7 @@ setup(
         'click',
         'requests',
         'lark-parser==0.5.6',
-        'pyhcl'
+        'pyhcl',
         'pyyaml',
         'pyaes'
     ],


### PR DESCRIPTION
A `,` was missing beside `pyhcl` in `cli/setup.py` file leading to install and build failures which is fixed through this PR.