### PR TITLE
Cleanup on Ctrl+C Signal

### DIFF
--- a/ci/cli.workflow
+++ b/ci/cli.workflow
@@ -63,6 +63,11 @@ action "test singularity" {
   runs = "singularity"
 }
 
+action "test interrupt" {
+  uses = "./ci/test"
+  runs = "interrupt"
+}
+
 action "end" {
   uses = "./ci/test"
   runs = "version"
@@ -79,6 +84,7 @@ action "end" {
     "test scaffold",
     "test parallel stage exec",
     "test dot",
-    "test singularity"
+    "test singularity",
+    "test interrupt"
   ]
 }

--- a/ci/test/interrupt
+++ b/ci/test/interrupt
@@ -20,30 +20,8 @@ kill -2 $pid
 sleep 5
 check="deploy branch-filter test lint install"
 actual=`docker ps -a --format "{{.Names}}"`
-for a in $actual
-do 
-  for b in $check
-  do 
-    if [ $a = $b ] 
-    then echo "fail" >> fail
-    fi
-  done
-done
 
-counter=`cat fail|wc -l`
-
-#A test for --parallel run
-popper run & pid=$!
-#Give popper run some time to create dockers
-sleep 8
-
-# -2 is for SIGINT or Ctrl-C
-kill -2 $pid
-
-#Give popper run some time to remove dockers and then check
-sleep 5
-
-actual=`docker ps -a --format "{{.Names}}"`
+cd ..
 for a in $actual
 do
   for b in $check
@@ -54,5 +32,82 @@ do
   done
 done
 
+
+#A test for --parallel run
+
+cat <<EOF > main.workflow
+workflow "test" {
+  resolves = ["sleep"]
+}
+
+action "sleep_20" {
+  uses = "docker://busybox"
+  args = ["sleep 20; echo 'slept for 20s'"]
+}
+
+action "sleep_30" {
+  uses = "docker://busybox"
+  args = ["sleep 30; echo 'slept for 30s'"]
+}
+
+action "sleep_50" {
+  uses = "docker://busybox"
+  args = ["sleep 50; echo 'slept for 50s'"]
+}
+
+action "sleep_100" {
+  uses = "docker://busybox"
+  args = ["sleep 100;", "echo 'slept for 100s'"]
+}
+
+action "sleep_200" {
+  uses = "docker://busybox"
+  args = ["sleep 200;", "echo 'slept for 200s'"]
+}
+
+action "sleep" {
+  uses = "docker://busybox"
+  needs = [
+    "sleep_20",
+    "sleep_30",
+    "sleep_50",
+    "sleep_100",
+    "sleep_200"
+  ]
+}
+
+EOF
+
+popper run --parallel & pid=$!
+#Give popper run some time to create dockers
+sleep 80
+
+# -2 is for SIGINT or Ctrl-C
+kill -2 $pid
+
+#Give popper run some time to remove dockers and then check
+sleep 20
+check="sleep_20 sleep_30 sleep_50 sleep_100 sleep_200 sleep"
+actual=`docker ps -a --format "{{.Names}}"`
+
+
+
+if [ -z $actual ]
+then
+  echo "Empty"
+else
+  for a in $actual
+    do
+      for b in $check
+      do
+        if [ $a = $b ]
+        then
+          echo "fail" >> fail
+        fi
+      done
+    done
+fi
+
+
 counter=`cat fail|wc -l`
-test $counter -eq 0
+test 0 -eq $counter

--- a/ci/test/interrupt
+++ b/ci/test/interrupt
@@ -10,8 +10,7 @@ git clone https://github.com/cplee/github-actions-demo.git
 cd github-actions-demo
 export PHONY_SECRET=foo
 popper run & pid=$!
-echo $!
-#Give popper run some time to creater dockers 
+#Give popper run some time to create dockers
 sleep 5
 
 # -2 is for SIGINT or Ctrl-C
@@ -26,6 +25,30 @@ do
   for b in $check
   do 
     if [ $a = $b ] 
+    then echo "fail" >> fail
+    fi
+  done
+done
+
+counter=`cat fail|wc -l`
+
+#A test for --parallel run
+popper run & pid=$!
+#Give popper run some time to create dockers
+sleep 10
+
+# -2 is for SIGINT or Ctrl-C
+kill -2 $pid
+
+#Give popper run some time to remove dockers and then check
+sleep 5
+
+actual=`docker ps -a --format "{{.Names}}"`
+for a in $actual
+do
+  for b in $check
+  do
+    if [ $a = $b ]
     then echo "fail" >> fail
     fi
   done

--- a/ci/test/interrupt
+++ b/ci/test/interrupt
@@ -1,0 +1,35 @@
+#!/bin/bash
+set -ex
+
+source ./common
+init_test_repo
+cd $test_repo_path
+
+git clone https://github.com/cplee/github-actions-demo.git
+
+cd github-actions-demo
+export PHONY_SECRET=foo
+popper run & pid=$!
+echo $!
+#Give popper run some time to creater dockers 
+sleep 5
+
+# -2 is for SIGINT or Ctrl-C
+kill -2 $pid
+
+#Give popper run some time to remove dockers and then check
+sleep 5
+check="deploy branch-filter test lint install"
+actual=`docker ps -a --format "{{.Names}}"`
+for a in $actual
+do 
+  for b in $check
+  do 
+    if [ $a = $b ] 
+    then echo "fail" >> fail
+    fi
+  done
+done
+
+counter=`cat fail|wc -l`
+test $counter -eq 0

--- a/ci/test/interrupt
+++ b/ci/test/interrupt
@@ -86,7 +86,7 @@ sleep 80
 kill -2 $pid
 
 #Give popper run some time to remove dockers and then check
-sleep 20
+sleep 200
 check="sleep_20 sleep_30 sleep_50 sleep_100 sleep_200 sleep"
 actual=`docker ps -a --format "{{.Names}}"`
 

--- a/ci/test/interrupt
+++ b/ci/test/interrupt
@@ -35,7 +35,7 @@ counter=`cat fail|wc -l`
 #A test for --parallel run
 popper run & pid=$!
 #Give popper run some time to create dockers
-sleep 10
+sleep 8
 
 # -2 is for SIGINT or Ctrl-C
 kill -2 $pid

--- a/cli/popper/cli.py
+++ b/cli/popper/cli.py
@@ -84,6 +84,7 @@ def signal_handler(sig, frame):
     cmd_out = set(cmd_out)
 
     for img in set(docker_list).intersection(cmd_out):
+        pu.exec_cmd('docker stop {}'.format(img))
         pu.exec_cmd('docker rm -f {}'.format(img))
         pu.info('\nDeleted {}'.format(img))
 

--- a/cli/popper/cli.py
+++ b/cli/popper/cli.py
@@ -74,10 +74,16 @@ def cli(ctx):
 
 docker_list = list()
 
+
 def signal_handler(sig, frame):
+
+    pu.info("\n")
+    cmd_out = pu.exec_cmd('docker ps -a')
     for img in docker_list:
-        pu.exec_cmd('docker rm {}'.format(img))
-        pu.info('Deleted {}'.format(img))
+        if img in cmd_out:
+            pu.exec_cmd('docker rm -f {}'.format(img))
+            pu.info('\nDeleted {}'.format(img))
+    pu.info("\n")
     os.killpg(os.getpid(), signal.SIGTERM)
 
     # Should never reach here, as parent process is also killed along with child processes

--- a/cli/popper/cli.py
+++ b/cli/popper/cli.py
@@ -89,5 +89,9 @@ def signal_handler(sig, frame):
 
 
     for pid in process_list:
-        os.kill(pid, signal.SIGTERM)
+        try:
+            os.kill(pid, signal.SIGTERM)
+        except ProcessLookupError:
+            # Process was probably already killed, so exit silenty
+            pass
     sys.exit(0)

--- a/cli/popper/cli.py
+++ b/cli/popper/cli.py
@@ -78,15 +78,15 @@ docker_list = list()
 def signal_handler(sig, frame):
 
     pu.info("\n")
-    cmd_out = pu.exec_cmd('docker ps -a')
-    for img in docker_list:
-        if img in cmd_out:
-            pu.exec_cmd('docker rm -f {}'.format(img))
-            pu.info('\nDeleted {}'.format(img))
-    pu.info("\n")
-    os.killpg(os.getpid(), signal.SIGTERM)
+    cmd_out = pu.exec_cmd('docker ps -a --format "{{.Names}}"')
+    cmd_out = cmd_out[0].splitlines()
+    cmd_out = set(cmd_out)
+
+    for img in set(docker_list).intersection(cmd_out):
+        pu.exec_cmd('docker rm -f {}'.format(img))
+        pu.info('\nDeleted {}'.format(img))
+    # os.killpg(os.getpid(), signal.SIGTERM)
 
     # Should never reach here,
     # as parent process is also killed along with child processes
-    print("Kill all processes")
     sys.exit(0)

--- a/cli/popper/cli.py
+++ b/cli/popper/cli.py
@@ -84,6 +84,7 @@ def signal_handler(sig, frame):
     if interrupt_params.parallel:
         for future in flist:
             future.cancel()     # Try to safely exit threads
+        time.sleep(50)      # Wait for some time
 
     # This will kill everything
     for pid in process_list:

--- a/cli/popper/cli.py
+++ b/cli/popper/cli.py
@@ -5,6 +5,7 @@ import click
 import difflib
 from . import __version__ as popper_version
 from .exceptions import UsageError
+import popper.utils as pu
 
 
 class Context(object):
@@ -74,8 +75,11 @@ def cli(ctx):
 docker_list = list()
 
 def signal_handler(sig, frame):
-    print("Kill all children")
-    print(docker_list)
-    # os.killpg(os.getpid(), signal.SIGTERM)
-    print("Kill all children")
+    for img in docker_list:
+        pu.exec_cmd('docker rm {}'.format(img))
+        pu.info('Deleted {}'.format(img))
+    os.killpg(os.getpid(), signal.SIGTERM)
+
+    # Should never reach here, as parent process is also killed along with child processes
+    print("Kill all processes")
     sys.exit(0)

--- a/cli/popper/cli.py
+++ b/cli/popper/cli.py
@@ -89,7 +89,7 @@ def signal_handler(sig, frame):
     for pid in process_list:
         try:
             os.kill(pid, signal.SIGTERM)
-        except ProcessLookupError:
+        except OSError:
             # Process was probably already killed, so exit silently
             pass
 

--- a/cli/popper/cli.py
+++ b/cli/popper/cli.py
@@ -1,4 +1,5 @@
 import os
+import signal
 import sys
 import click
 import difflib
@@ -67,3 +68,14 @@ class PopperCLI(click.MultiCommand):
 @pass_context
 def cli(ctx):
     """Popper command line interface."""
+    signal.signal(signal.SIGINT, signal_handler)
+
+
+docker_list = list()
+
+def signal_handler(sig, frame):
+    print("Kill all children")
+    print(docker_list)
+    # os.killpg(os.getpid(), signal.SIGTERM)
+    print("Kill all children")
+    sys.exit(0)

--- a/cli/popper/cli.py
+++ b/cli/popper/cli.py
@@ -73,6 +73,7 @@ def cli(ctx):
 
 
 docker_list = list()
+process_list = list()
 
 
 def signal_handler(sig, frame):
@@ -85,8 +86,8 @@ def signal_handler(sig, frame):
     for img in set(docker_list).intersection(cmd_out):
         pu.exec_cmd('docker rm -f {}'.format(img))
         pu.info('\nDeleted {}'.format(img))
-    # os.killpg(os.getpid(), signal.SIGTERM)
 
-    # Should never reach here,
-    # as parent process is also killed along with child processes
+
+    for pid in process_list:
+        os.kill(pid, signal.SIGTERM)
     sys.exit(0)

--- a/cli/popper/cli.py
+++ b/cli/popper/cli.py
@@ -86,6 +86,7 @@ def signal_handler(sig, frame):
     pu.info("\n")
     os.killpg(os.getpid(), signal.SIGTERM)
 
-    # Should never reach here, as parent process is also killed along with child processes
+    # Should never reach here,
+    # as parent process is also killed along with child processes
     print("Kill all processes")
     sys.exit(0)

--- a/cli/popper/cli.py
+++ b/cli/popper/cli.py
@@ -74,6 +74,7 @@ def cli(ctx):
 
 docker_list = list()
 process_list = list()
+interrupt_params = None
 
 
 def signal_handler(sig, frame):
@@ -85,14 +86,19 @@ def signal_handler(sig, frame):
 
     for img in set(docker_list).intersection(cmd_out):
         pu.exec_cmd('docker stop {}'.format(img))
-        pu.exec_cmd('docker rm -f {}'.format(img))
-        pu.info('\nDeleted {}'.format(img))
-
+        if interrupt_params.reuse:
+            pu.info('--reuse flag is set. Retaining containers')
+            msg = '\nStopping {}'.format(img)
+        else:
+            msg = '\nDeleting {}'.format(img)
+            pu.exec_cmd('docker rm -f {}'.format(img))
+        pu.info(msg)
+    pu.info('\n')
 
     for pid in process_list:
         try:
             os.kill(pid, signal.SIGTERM)
         except ProcessLookupError:
-            # Process was probably already killed, so exit silenty
+            # Process was probably already killed, so exit silently
             pass
     sys.exit(0)

--- a/cli/popper/commands/cmd_dot.py
+++ b/cli/popper/commands/cmd_dot.py
@@ -37,7 +37,7 @@ def cli(ctx, wfile, recursive):
         wfile_list.append(pu.find_default_wfile(wfile))
 
     for wfile in wfile_list:
-        pipeline = Workflow(wfile, False, False, False, False, False)
+        pipeline = Workflow(wfile, False, False, False, False, False, False)
 
         graph = list()
 

--- a/cli/popper/commands/cmd_dot.py
+++ b/cli/popper/commands/cmd_dot.py
@@ -37,7 +37,7 @@ def cli(ctx, wfile, recursive):
         wfile_list.append(pu.find_default_wfile(wfile))
 
     for wfile in wfile_list:
-        pipeline = Workflow(wfile, False, False, False, False)
+        pipeline = Workflow(wfile, False, False, False, False, False)
 
         graph = list()
 

--- a/cli/popper/commands/cmd_run.py
+++ b/cli/popper/commands/cmd_run.py
@@ -6,6 +6,7 @@ import popper.utils as pu
 
 from popper.gha import Workflow
 from popper.cli import pass_context
+import popper.cli
 
 
 @click.command(
@@ -84,7 +85,10 @@ def cli(ctx, action, wfile, workspace, reuse,
 
 def run_pipeline(action, wfile, workspace, reuse,
                  quiet, debug, dry_run, parallel):
-    pipeline = Workflow(wfile, workspace, quiet, debug, dry_run)
+    pipeline = Workflow(wfile, workspace, quiet, debug, dry_run, reuse)
+
+    # Saving workflow instance for signal handling
+    popper.cli.interrupt_params = pipeline
 
     if reuse:
         pu.info(

--- a/cli/popper/commands/cmd_run.py
+++ b/cli/popper/commands/cmd_run.py
@@ -85,7 +85,8 @@ def cli(ctx, action, wfile, workspace, reuse,
 
 def run_pipeline(action, wfile, workspace, reuse,
                  quiet, debug, dry_run, parallel):
-    pipeline = Workflow(wfile, workspace, quiet, debug, dry_run, reuse)
+    pipeline = Workflow(wfile, workspace, quiet, debug, dry_run,
+                        reuse, parallel)
 
     # Saving workflow instance for signal handling
     popper.cli.interrupt_params = pipeline

--- a/cli/popper/gha.py
+++ b/cli/popper/gha.py
@@ -15,7 +15,7 @@ class Workflow(object):
     """A GHA workflow.
     """
 
-    def __init__(self, wfile, workspace, quiet, debug, dry_run, reuse):
+    def __init__(self, wfile, workspace, quiet, debug, dry_run, reuse, parallel):
         wfile = pu.find_default_wfile(wfile)
 
         with open(wfile, 'r') as fp:
@@ -29,6 +29,7 @@ class Workflow(object):
             self.quiet = quiet
         self.dry_run = dry_run
         self.reuse = reuse
+        self.parallel = parallel
 
         self.actions_cache_path = os.path.join('/', 'tmp', 'actions')
         self.validate_syntax()
@@ -317,6 +318,7 @@ class Workflow(object):
                     ex.submit(self.wf['action'][a]['runner'].run, reuse):
                     a for a in stage
                 }
+                popper.cli.flist = flist
                 for future in as_completed(flist):
                     try:
                         future.result()

--- a/cli/popper/gha.py
+++ b/cli/popper/gha.py
@@ -15,7 +15,7 @@ class Workflow(object):
     """A GHA workflow.
     """
 
-    def __init__(self, wfile, workspace, quiet, debug, dry_run):
+    def __init__(self, wfile, workspace, quiet, debug, dry_run, reuse):
         wfile = pu.find_default_wfile(wfile)
 
         with open(wfile, 'r') as fp:
@@ -28,6 +28,7 @@ class Workflow(object):
         else:
             self.quiet = quiet
         self.dry_run = dry_run
+        self.reuse = reuse
 
         self.actions_cache_path = os.path.join('/', 'tmp', 'actions')
         self.validate_syntax()

--- a/cli/popper/gha.py
+++ b/cli/popper/gha.py
@@ -7,9 +7,6 @@ import os
 import popper.utils as pu
 import popper.scm as scm
 from spython.main import Client
-import signal
-import subprocess
-import time
 import sys
 import popper.cli
 

--- a/cli/popper/gha.py
+++ b/cli/popper/gha.py
@@ -7,7 +7,11 @@ import os
 import popper.utils as pu
 import popper.scm as scm
 from spython.main import Client
-
+import signal
+import subprocess
+import time
+import sys
+import popper.cli
 
 class Workflow(object):
     """A GHA workflow.
@@ -371,6 +375,7 @@ class DockerRunner(ActionRunner):
     def __init__(self, action, workspace, env, q, d, dry):
         super(DockerRunner, self).__init__(action, workspace, env, q, d, dry)
         self.cid = self.action['name'].replace(' ', '_')
+        popper.cli.docker_list.append(self.cid)
 
     def run(self, reuse):
         build = True

--- a/cli/popper/gha.py
+++ b/cli/popper/gha.py
@@ -13,6 +13,7 @@ import time
 import sys
 import popper.cli
 
+
 class Workflow(object):
     """A GHA workflow.
     """

--- a/cli/popper/utils.py
+++ b/cli/popper/utils.py
@@ -4,6 +4,7 @@ import sys
 import time
 import yaml
 import threading
+import popper.cli
 from subprocess import check_output, CalledProcessError, PIPE, Popen, STDOUT
 
 noalias_dumper = yaml.dumper.SafeDumper
@@ -187,11 +188,13 @@ def exec_cmd(cmd, verbose=False, debug=False, ignore_error=False,
                 info('DEBUG: subprocess.Popen() with combined stdout/stderr\n')
             p = Popen(cmd, stdout=PIPE, stderr=STDOUT, shell=True,
                       universal_newlines=True)
+            popper.cli.process_list.append(p.pid)
         else:
             if debug:
                 info('DEBUG: subprocess.Popen() with separate stdout/stderr\n')
             p = Popen(cmd, stdout=outf, stderr=errf, shell=True,
                       universal_newlines=True)
+            popper.cli.process_list.append(p.pid)
 
         if debug:
             info('DEBUG: Reading process output\n')

--- a/cli/popper/utils.py
+++ b/cli/popper/utils.py
@@ -188,13 +188,12 @@ def exec_cmd(cmd, verbose=False, debug=False, ignore_error=False,
                 info('DEBUG: subprocess.Popen() with combined stdout/stderr\n')
             p = Popen(cmd, stdout=PIPE, stderr=STDOUT, shell=True,
                       universal_newlines=True)
-            popper.cli.process_list.append(p.pid)
         else:
             if debug:
                 info('DEBUG: subprocess.Popen() with separate stdout/stderr\n')
             p = Popen(cmd, stdout=outf, stderr=errf, shell=True,
                       universal_newlines=True)
-            popper.cli.process_list.append(p.pid)
+        popper.cli.process_list.append(p.pid)
 
         if debug:
             info('DEBUG: Reading process output\n')


### PR DESCRIPTION
Issue #505: Cleanup docker containers created during `popper run`

Output generated on running `popper run` on this [workflow](https://github.com/cplee/github-actions-demo/blob/master/.github/main.workflow)
```
Already on 'master'
[install] docker pull node:11.6.0
[install] docker create node:11.6.0 npm install
[install] docker start ..
[test] docker pull node:11.6.0
[test] docker create node:11.6.0 npm test
[test] docker start .
[lint] docker build -t action/jshint /root/github-actions-demo/./.github/actions/jshint
[lint] docker create action/jshint 
[lint] docker start .
[branch-filter] docker build -t actions/bin /tmp/actions/actions/bin/./filter
[branch-filter] docker create actions/bin branch master
[branch-filter] docker start .
[deploy] docker build -t actions/bin /tmp/actions/actions/bin/./sh
^C

Deleted install
Deleted test
Deleted lint
Deleted branch-filter
Terminated
```