### PR TITLE
Add some dry-run test fixes

### DIFF
--- a/ci/test/dry-run
+++ b/ci/test/dry-run
@@ -78,12 +78,11 @@ check_count=`cat check | wc -m`
 
 if [ $count1 -eq $check_count ]; then
 diff 1 check
-fi
-
-if [ $count2 -eq $check_count ]; then
+elif [ $count2 -eq $check_count ]; then
 diff 2 check
-fi
-
-if [ $count3 -eq $check_count ]; then
+elif [ $count3 -eq $check_count ]; then
 diff 3 check
+else
+echo ""> empty
+diff empty check  #Fail scenarrio
 fi

--- a/ci/test/dry-run
+++ b/ci/test/dry-run
@@ -29,12 +29,61 @@ DRYRUN: [deploy] docker create actions/bin env
 DRYRUN: [deploy] docker start
 
 Workflow finished successfully.
-" > expected
+" > expected_1
+
+
+echo "DRYRUN: [install] docker pull node:11.6.0
+DRYRUN: [install] docker create node:11.6.0 npm install
+DRYRUN: [install] docker start
+DRYRUN: [lint] ./entrypoint.sh
+DRYRUN: [test] docker pull node:11.6.0
+DRYRUN: [test] docker create node:11.6.0 npm test
+DRYRUN: [test] docker start
+DRYRUN: [branch-filter] ./entrypoint.sh branch master
+DRYRUN: [deploy] ./entrypoint.sh env
+
+Workflow finished successfully.
+" > expected_2
+
+
+echo "DRYRUN: [install] docker pull node:11.6.0
+DRYRUN: [install] docker create node:11.6.0 npm install
+DRYRUN: [install] docker start
+DRYRUN: [lint] docker build -t action/jshint /tmp/mypaper/github-actions-demo/./.github/actions/jshint
+DRYRUN: [lint] docker create action/jshint
+DRYRUN: [lint] docker start
+DRYRUN: [test] docker pull node:11.6.0
+DRYRUN: [test] docker create node:11.6.0 npm test
+DRYRUN: [test] docker start
+DRYRUN: [branch-filter] ./entrypoint.sh branch master
+DRYRUN: [deploy] ./entrypoint.sh env
+
+Workflow finished successfully.
+" > expected_3
+
 
 # Using xargs to remove trailing whitespaces
 # Even tr -s '\n' '\n' is for the same purpose
 # Using sort so as to get some appearance of order
 
-cat expected | tr -s '\n' '\n' | sort | xargs > a
-cat actual | tr -s '\n' '\n' | sort | xargs> b
-diff a b
+cat expected_1 | tr -s '\n' '\n' | sort | xargs > 1
+cat expected_2 | tr -s '\n' '\n' | sort | xargs > 2
+cat expected_3 | tr -s '\n' '\n' | sort | xargs > 3
+cat actual | tr -s '\n' '\n' | sort | xargs> check
+
+count1=`cat 1 | wc -m`
+count2=`cat 2 | wc -m`
+count3=`cat 3 | wc -m`
+check_count=`cat check | wc -m`
+
+if [ $count1 -eq $check_count ]; then
+diff 1 check
+fi
+
+if [ $count2 -eq $check_count ]; then
+diff 2 check
+fi
+
+if [ $count3 -eq $check_count ]; then
+diff 3 check
+fi


### PR DESCRIPTION
Address Issue #556 
Hi @ivotron, so I was actually checking the dry-run test. So I found that `dry-run` gave different outputs according to different scenarios. So I integrated those in the test.
Scenario 1: Which was occurring most frequently. It is also appeared as a build fail when I rebased #530 [here](https://travis-ci.org/systemslab/popper/jobs/510243060#L294-L303). It happens when the `HostRunner` is called instead of `DockerRunner` class.
(https://travis-ci.org/systemslab/popper/jobs/510243060#L294-L303) https://github.com/systemslab/popper/blob/f4eb8078c23b497faba6de9746984ad526f1861b/ci/test/dry-run#L49-L59
Scenario 2: It happened only once on my local. Thereafter I couldn't reproduce it, but I included it for good measure
https://github.com/systemslab/popper/blob/f4eb8078c23b497faba6de9746984ad526f1861b/ci/test/dry-run#L35-L43


