### PR TITLE
Fixes #533 Modifies the cloned actions path

### DIFF
--- a/ci/test/dry-run
+++ b/ci/test/dry-run
@@ -21,10 +21,10 @@ DRYRUN: [test] docker start
 DRYRUN: [lint] docker build -t action/jshint $PWD/./.github/actions/jshint
 DRYRUN: [lint] docker create action/jshint
 DRYRUN: [lint] docker start
-DRYRUN: [branch-filter] docker build -t actions/bin /tmp/actions/actions/bin/./filter
+DRYRUN: [branch-filter] docker build -t actions/bin /tmp/actions/github.com/actions/bin/./filter
 DRYRUN: [branch-filter] docker create actions/bin branch master
 DRYRUN: [branch-filter] docker start
-DRYRUN: [deploy] docker build -t actions/bin /tmp/actions/actions/bin/./sh
+DRYRUN: [deploy] docker build -t actions/bin /tmp/actions/github.com/actions/bin/./sh
 DRYRUN: [deploy] docker create actions/bin env
 DRYRUN: [deploy] docker start
 

--- a/cli/popper/gha.py
+++ b/cli/popper/gha.py
@@ -197,21 +197,25 @@ class Workflow(object):
                 a['uses'] = a['uses'][8:]
                 parts = a['uses'].split('/')
                 url = 'https://' + parts[0]
+                service = parts[0]
                 user = parts[1]
                 repo = parts[2]
             elif a['uses'].startswith('http://'):
                 a['uses'] = a['uses'][7:]
                 parts = a['uses'].split('/')
                 url = 'http://' + parts[0]
+                service = parts[0]
                 user = parts[1]
                 repo = parts[2]
             elif a['uses'].startswith('git@'):
                 url, rest = a['uses'].split(':')
                 user, repo = rest.split('/')
+                service = url[4:]
             elif a['uses'].startswith('ssh://'):
                 pu.fail("The ssh protocol is not supported yet.")
             else:
                 url = 'https://github.com'
+                service = 'github.com'
                 parts = a['uses'].split('/')
                 user = a['uses'].split('/')[0]
                 repo = a['uses'].split('/')[1]
@@ -228,8 +232,7 @@ class Workflow(object):
                 version = None
             action_dir = os.path.join('./', action_dir)
 
-            repo_parent_dir = os.path.join(self.actions_cache_path, user)
-
+            repo_parent_dir = os.path.join(self.actions_cache_path, service, user)
             a['repo_dir'] = os.path.join(repo_parent_dir, repo)
             a['action_dir'] = action_dir
             if '{}/{}'.format(user, repo) in cloned:

--- a/cli/popper/gha.py
+++ b/cli/popper/gha.py
@@ -232,7 +232,9 @@ class Workflow(object):
                 version = None
             action_dir = os.path.join('./', action_dir)
 
-            repo_parent_dir = os.path.join(self.actions_cache_path, service, user)
+            repo_parent_dir = os.path.join(
+                self.actions_cache_path, service, user
+            )
             a['repo_dir'] = os.path.join(repo_parent_dir, repo)
             a['action_dir'] = action_dir
             if '{}/{}'.format(user, repo) in cloned:


### PR DESCRIPTION
Now , the actions from github, gitlab etc. get cloned to `/tmp/actions/github.com/org/repo/`, `/tmp/actions/gitlab.com/org/repo/` etc. Hence a local clone of any repo gets correctly identified.