### PR TITLE
Fixes #564 Implements popper add

### DIFF
--- a/ci/cli.workflow
+++ b/ci/cli.workflow
@@ -68,6 +68,11 @@ action "test interrupt" {
   runs = "interrupt"
 }
 
+action "test add" {
+  uses = "./ci/test"
+  runs = "add"
+}
+
 action "end" {
   uses = "./ci/test"
   runs = "version"
@@ -85,6 +90,7 @@ action "end" {
     "test parallel",
     "test dot",
     "test singularity",
-    "test interrupt"
+    "test interrupt",
+    "test add"
   ]
 }

--- a/ci/test/add
+++ b/ci/test/add
@@ -1,0 +1,25 @@
+#!/bin/bash
+set -ex
+
+source ./common
+init_test_repo
+cd $test_repo_path
+
+popper init
+
+popper add cplee/github-actions-demo
+test -f /tmp/mypaper/workflows/.github/actions/jshint/Dockerfile
+test -f /tmp/mypaper/workflows/.github/main.workflow
+rm -rf workflows
+
+popper add cplee/github-actions-demo/.github/
+test -f /tmp/mypaper/workflows/.github/actions/jshint/Dockerfile
+test -f /tmp/mypaper/workflows/.github/main.workflow
+rm -rf workflows
+
+popper add cplee/github-actions-demo/.github/main.workflow
+test -f /tmp/mypaper/workflows/.github/actions/jshint/Dockerfile
+test -f /tmp/mypaper/workflows/.github/main.workflow
+rm -rf workflows
+
+echo "Popper add command ran successfully !"

--- a/ci/test/add
+++ b/ci/test/add
@@ -8,18 +8,15 @@ cd $test_repo_path
 popper init
 
 popper add cplee/github-actions-demo
-test -f /tmp/mypaper/workflows/.github/actions/jshint/Dockerfile
-test -f /tmp/mypaper/workflows/.github/main.workflow
-rm -rf workflows
+test -f /tmp/mypaper/.github/actions/jshint/Dockerfile
+test -f /tmp/mypaper/main.workflow
 
 popper add cplee/github-actions-demo/.github/
-test -f /tmp/mypaper/workflows/.github/actions/jshint/Dockerfile
-test -f /tmp/mypaper/workflows/.github/main.workflow
-rm -rf workflows
+test -f /tmp/mypaper/.github/actions/jshint/Dockerfile
+test -f /tmp/mypaper/main.workflow
 
 popper add cplee/github-actions-demo/.github/main.workflow
-test -f /tmp/mypaper/workflows/.github/actions/jshint/Dockerfile
-test -f /tmp/mypaper/workflows/.github/main.workflow
-rm -rf workflows
+test -f /tmp/mypaper/.github/actions/jshint/Dockerfile
+test -f /tmp/mypaper/main.workflow
 
 echo "Popper add command ran successfully !"

--- a/ci/test/add
+++ b/ci/test/add
@@ -7,16 +7,29 @@ cd $test_repo_path
 
 popper init
 
-popper add cplee/github-actions-demo
+popper add github.com/cplee/github-actions-demo
 test -f /tmp/mypaper/.github/actions/jshint/Dockerfile
 test -f /tmp/mypaper/main.workflow
 
-popper add cplee/github-actions-demo/.github/
+popper add github.com/cplee/github-actions-demo/.github/
 test -f /tmp/mypaper/.github/actions/jshint/Dockerfile
 test -f /tmp/mypaper/main.workflow
 
-popper add cplee/github-actions-demo/.github/main.workflow
+popper add github.com/cplee/github-actions-demo/.github/main.workflow
 test -f /tmp/mypaper/.github/actions/jshint/Dockerfile
 test -f /tmp/mypaper/main.workflow
+
+popper add github.com/JayjeetAtGithub/github-actions-demo@develop
+test -f /tmp/mypaper/.github/actions/jshint/Dockerfile
+test -f /tmp/mypaper/main.workflow
+
+popper add github.com/JayjeetAtGithub/github-actions-demo/.github@develop
+test -f /tmp/mypaper/.github/actions/jshint/Dockerfile
+test -f /tmp/mypaper/main.workflow
+
+popper add github.com/JayjeetAtGithub/github-actions-demo/.github/main.workflow@develop
+test -f /tmp/mypaper/.github/actions/jshint/Dockerfile
+test -f /tmp/mypaper/main.workflow
+
 
 echo "Popper add command ran successfully !"

--- a/ci/test/add
+++ b/ci/test/add
@@ -7,6 +7,18 @@ cd $test_repo_path
 
 popper init
 
+popper add https://github.com/actions/bin@master
+test -f /tmp/mypaper/main.workflow
+rm /tmp/mypaper/main.workflow
+
+popper add https://github.com/actions/bin/.github@master
+test -f /tmp/mypaper/main.workflow
+rm /tmp/mypaper/main.workflow
+
+popper add https://github.com/actions/bin/.github/main.workflow@master
+test -f /tmp/mypaper/main.workflow
+rm /tmp/mypaper/main.workflow
+
 popper add cplee/github-actions-demo@master
 test -f /tmp/mypaper/.github/actions/jshint/Dockerfile
 test -f /tmp/mypaper/main.workflow

--- a/ci/test/add
+++ b/ci/test/add
@@ -19,6 +19,18 @@ popper add github.com/cplee/github-actions-demo/.github/main.workflow
 test -f /tmp/mypaper/.github/actions/jshint/Dockerfile
 test -f /tmp/mypaper/main.workflow
 
+popper add gitlab.com/JayjeetAtGithub/github-actions-demo
+test -f /tmp/mypaper/.github/actions/jshint/Dockerfile
+test -f /tmp/mypaper/main.workflow
+
+popper add gitlab.com/JayjeetAtGithub/github-actions-demo/.github/
+test -f /tmp/mypaper/.github/actions/jshint/Dockerfile
+test -f /tmp/mypaper/main.workflow
+
+popper add gitlab.com/JayjeetAtGithub/github-actions-demo/.github/main.workflow
+test -f /tmp/mypaper/.github/actions/jshint/Dockerfile
+test -f /tmp/mypaper/main.workflow
+
 popper add github.com/JayjeetAtGithub/github-actions-demo@develop
 test -f /tmp/mypaper/.github/actions/jshint/Dockerfile
 test -f /tmp/mypaper/main.workflow
@@ -31,5 +43,16 @@ popper add github.com/JayjeetAtGithub/github-actions-demo/.github/main.workflow@
 test -f /tmp/mypaper/.github/actions/jshint/Dockerfile
 test -f /tmp/mypaper/main.workflow
 
+popper add gitlab.com/JayjeetAtGithub/github-actions-demo@develop
+test -f /tmp/mypaper/.github/actions/jshint/Dockerfile
+test -f /tmp/mypaper/main.workflow
+
+popper add gitlab.com/JayjeetAtGithub/github-actions-demo/.github@develop
+test -f /tmp/mypaper/.github/actions/jshint/Dockerfile
+test -f /tmp/mypaper/main.workflow
+
+popper add gitlab.com/JayjeetAtGithub/github-actions-demo/.github/main.workflow@develop
+test -f /tmp/mypaper/.github/actions/jshint/Dockerfile
+test -f /tmp/mypaper/main.workflow
 
 echo "Popper add command ran successfully !"

--- a/ci/test/add
+++ b/ci/test/add
@@ -7,51 +7,64 @@ cd $test_repo_path
 
 popper init
 
-popper add github.com/cplee/github-actions-demo
+popper add cplee/github-actions-demo@master
 test -f /tmp/mypaper/.github/actions/jshint/Dockerfile
 test -f /tmp/mypaper/main.workflow
 
-popper add github.com/cplee/github-actions-demo/.github/
+popper add cplee/github-actions-demo@master
 test -f /tmp/mypaper/.github/actions/jshint/Dockerfile
 test -f /tmp/mypaper/main.workflow
 
-popper add github.com/cplee/github-actions-demo/.github/main.workflow
+popper add cplee/github-actions-demo@master
 test -f /tmp/mypaper/.github/actions/jshint/Dockerfile
 test -f /tmp/mypaper/main.workflow
 
-popper add gitlab.com/JayjeetAtGithub/github-actions-demo
+
+popper add https://github.com/cplee/github-actions-demo@master
 test -f /tmp/mypaper/.github/actions/jshint/Dockerfile
 test -f /tmp/mypaper/main.workflow
 
-popper add gitlab.com/JayjeetAtGithub/github-actions-demo/.github/
+popper add https://github.com/cplee/github-actions-demo/.github@master
 test -f /tmp/mypaper/.github/actions/jshint/Dockerfile
 test -f /tmp/mypaper/main.workflow
 
-popper add gitlab.com/JayjeetAtGithub/github-actions-demo/.github/main.workflow
+popper add https://github.com/cplee/github-actions-demo/.github/main.workflow@master
 test -f /tmp/mypaper/.github/actions/jshint/Dockerfile
 test -f /tmp/mypaper/main.workflow
 
-popper add github.com/JayjeetAtGithub/github-actions-demo@develop
+popper add https://gitlab.com/JayjeetAtGithub/github-actions-demo@master
 test -f /tmp/mypaper/.github/actions/jshint/Dockerfile
 test -f /tmp/mypaper/main.workflow
 
-popper add github.com/JayjeetAtGithub/github-actions-demo/.github@develop
+popper add https://gitlab.com/JayjeetAtGithub/github-actions-demo/.github@master
 test -f /tmp/mypaper/.github/actions/jshint/Dockerfile
 test -f /tmp/mypaper/main.workflow
 
-popper add github.com/JayjeetAtGithub/github-actions-demo/.github/main.workflow@develop
+popper add https://gitlab.com/JayjeetAtGithub/github-actions-demo/.github/main.workflow@master
 test -f /tmp/mypaper/.github/actions/jshint/Dockerfile
 test -f /tmp/mypaper/main.workflow
 
-popper add gitlab.com/JayjeetAtGithub/github-actions-demo@develop
+popper add https://github.com/JayjeetAtGithub/github-actions-demo@develop
 test -f /tmp/mypaper/.github/actions/jshint/Dockerfile
 test -f /tmp/mypaper/main.workflow
 
-popper add gitlab.com/JayjeetAtGithub/github-actions-demo/.github@develop
+popper add https://github.com/JayjeetAtGithub/github-actions-demo/.github@develop
 test -f /tmp/mypaper/.github/actions/jshint/Dockerfile
 test -f /tmp/mypaper/main.workflow
 
-popper add gitlab.com/JayjeetAtGithub/github-actions-demo/.github/main.workflow@develop
+popper add https://github.com/JayjeetAtGithub/github-actions-demo/.github/main.workflow@develop
+test -f /tmp/mypaper/.github/actions/jshint/Dockerfile
+test -f /tmp/mypaper/main.workflow
+
+popper add https://gitlab.com/JayjeetAtGithub/github-actions-demo@develop
+test -f /tmp/mypaper/.github/actions/jshint/Dockerfile
+test -f /tmp/mypaper/main.workflow
+
+popper add https://gitlab.com/JayjeetAtGithub/github-actions-demo/.github@develop
+test -f /tmp/mypaper/.github/actions/jshint/Dockerfile
+test -f /tmp/mypaper/main.workflow
+
+popper add https://gitlab.com/JayjeetAtGithub/github-actions-demo/.github/main.workflow@develop
 test -f /tmp/mypaper/.github/actions/jshint/Dockerfile
 test -f /tmp/mypaper/main.workflow
 

--- a/ci/test/add
+++ b/ci/test/add
@@ -10,62 +10,91 @@ popper init
 popper add cplee/github-actions-demo@master
 test -f /tmp/mypaper/.github/actions/jshint/Dockerfile
 test -f /tmp/mypaper/main.workflow
+rm -rf /tmp/mypaper/.github
+rm /tmp/mypaper/main.workflow
 
 popper add cplee/github-actions-demo@master
 test -f /tmp/mypaper/.github/actions/jshint/Dockerfile
 test -f /tmp/mypaper/main.workflow
+rm -rf /tmp/mypaper/.github
+rm /tmp/mypaper/main.workflow
 
 popper add cplee/github-actions-demo@master
 test -f /tmp/mypaper/.github/actions/jshint/Dockerfile
 test -f /tmp/mypaper/main.workflow
-
+rm -rf /tmp/mypaper/.github
+rm /tmp/mypaper/main.workflow
 
 popper add https://github.com/cplee/github-actions-demo@master
 test -f /tmp/mypaper/.github/actions/jshint/Dockerfile
 test -f /tmp/mypaper/main.workflow
+rm -rf /tmp/mypaper/.github
+rm /tmp/mypaper/main.workflow
 
 popper add https://github.com/cplee/github-actions-demo/.github@master
 test -f /tmp/mypaper/.github/actions/jshint/Dockerfile
 test -f /tmp/mypaper/main.workflow
+rm -rf /tmp/mypaper/.github
+rm /tmp/mypaper/main.workflow
 
 popper add https://github.com/cplee/github-actions-demo/.github/main.workflow@master
 test -f /tmp/mypaper/.github/actions/jshint/Dockerfile
 test -f /tmp/mypaper/main.workflow
+rm -rf /tmp/mypaper/.github
+rm /tmp/mypaper/main.workflow
 
 popper add https://gitlab.com/JayjeetAtGithub/github-actions-demo@master
 test -f /tmp/mypaper/.github/actions/jshint/Dockerfile
 test -f /tmp/mypaper/main.workflow
+rm -rf /tmp/mypaper/.github
+rm /tmp/mypaper/main.workflow
 
 popper add https://gitlab.com/JayjeetAtGithub/github-actions-demo/.github@master
 test -f /tmp/mypaper/.github/actions/jshint/Dockerfile
 test -f /tmp/mypaper/main.workflow
+rm -rf /tmp/mypaper/.github
+rm /tmp/mypaper/main.workflow
 
 popper add https://gitlab.com/JayjeetAtGithub/github-actions-demo/.github/main.workflow@master
 test -f /tmp/mypaper/.github/actions/jshint/Dockerfile
 test -f /tmp/mypaper/main.workflow
+rm -rf /tmp/mypaper/.github
+rm /tmp/mypaper/main.workflow
 
 popper add https://github.com/JayjeetAtGithub/github-actions-demo@develop
 test -f /tmp/mypaper/.github/actions/jshint/Dockerfile
 test -f /tmp/mypaper/main.workflow
+rm -rf /tmp/mypaper/.github
+rm /tmp/mypaper/main.workflow
 
 popper add https://github.com/JayjeetAtGithub/github-actions-demo/.github@develop
 test -f /tmp/mypaper/.github/actions/jshint/Dockerfile
 test -f /tmp/mypaper/main.workflow
+rm -rf /tmp/mypaper/.github
+rm /tmp/mypaper/main.workflow
 
 popper add https://github.com/JayjeetAtGithub/github-actions-demo/.github/main.workflow@develop
 test -f /tmp/mypaper/.github/actions/jshint/Dockerfile
 test -f /tmp/mypaper/main.workflow
+rm -rf /tmp/mypaper/.github
+rm /tmp/mypaper/main.workflow
 
 popper add https://gitlab.com/JayjeetAtGithub/github-actions-demo@develop
 test -f /tmp/mypaper/.github/actions/jshint/Dockerfile
 test -f /tmp/mypaper/main.workflow
+rm -rf /tmp/mypaper/.github
+rm /tmp/mypaper/main.workflow
 
 popper add https://gitlab.com/JayjeetAtGithub/github-actions-demo/.github@develop
 test -f /tmp/mypaper/.github/actions/jshint/Dockerfile
 test -f /tmp/mypaper/main.workflow
+rm -rf /tmp/mypaper/.github
+rm /tmp/mypaper/main.workflow
 
 popper add https://gitlab.com/JayjeetAtGithub/github-actions-demo/.github/main.workflow@develop
 test -f /tmp/mypaper/.github/actions/jshint/Dockerfile
 test -f /tmp/mypaper/main.workflow
+rm -rf /tmp/mypaper/.github
+rm /tmp/mypaper/main.workflow
 
 echo "Popper add command ran successfully !"

--- a/cli/popper/commands/cmd_add.py
+++ b/cli/popper/commands/cmd_add.py
@@ -17,5 +17,7 @@ def cli(ctx, path):
     if not pu.is_popperized(project_root):
         pu.fail('Repository has not been popperized.')
         return
-
-    Workflow.import_from_repo(path, project_root)
+    try:
+        Workflow.import_from_repo(path, project_root)
+    except Exception as e:
+        pu.fail('Failed to import from {} !'.format(path))

--- a/cli/popper/commands/cmd_add.py
+++ b/cli/popper/commands/cmd_add.py
@@ -42,12 +42,12 @@ def cli(ctx, path, branch):
     )
 
     if len(parts) == 2:
-        ptw1 = os.path.join(cloned_project_dir, "main.workflow")
-        ptw2 = os.path.join(cloned_project_dir, ".github/main.workflow")
-        if os.path.isfile(ptw1):
-            path_to_workflow = ptw1
-        elif os.path.isfile(ptw2):
-            path_to_workflow = ptw2
+        ptw_one = os.path.join(cloned_project_dir, "main.workflow")
+        ptw_two = os.path.join(cloned_project_dir, ".github/main.workflow")
+        if os.path.isfile(ptw_one):
+            path_to_workflow = ptw_one
+        elif os.path.isfile(ptw_two):
+            path_to_workflow = ptw_two
         else:
             pu.fail("Unable to find a .workflow file")
     elif len(parts) >= 3:

--- a/cli/popper/commands/cmd_add.py
+++ b/cli/popper/commands/cmd_add.py
@@ -1,0 +1,75 @@
+import click
+import os
+import hcl
+import errno
+import shutil
+import popper.utils as pu
+import popper.scm as scm
+from popper.cli import pass_context
+from distutils.dir_util import copy_tree
+
+@click.command('add', short_help='Import workflow from remote repo.')
+@click.argument('path', required=True)
+@click.option(
+    '--branch',
+    help='Specifies the branch to download from.',
+    required=False,
+    default='master'
+)
+@pass_context
+def cli(ctx, path, branch):
+    """Imports a workflow from a remote project to the current project
+    directory. For now it can import workflows only from repos hosted at
+    github.com
+    """
+    project_root = scm.get_root_folder()
+    if not pu.is_popperized(project_root):
+        pu.fail('Repository has not been popperized.')
+        return
+
+    parts = path.split('/')
+    parts = list(filter(None, parts))
+    if len(parts) < 2:
+        pu.fail('Remote url format should be  <repo>[/folder[/wf.workflow]]')
+
+    org = parts[0]
+    repo = parts[1]
+    
+    cloned_project_dir = os.path.join("/tmp", org, repo)
+    scm.clone('https://github.com', org, repo, os.path.dirname(
+        cloned_project_dir)
+    )
+
+    if len(parts) == 2:
+        ptw1 = os.path.join(cloned_project_dir, "main.workflow")
+        ptw2 = os.path.join(cloned_project_dir, ".github/main.workflow")
+        if os.path.isfile(ptw1):
+            path_to_workflow = ptw1
+        elif os.path.isfile(ptw2):
+            path_to_workflow = ptw2
+        else:
+            pu.fail("Unable to find a .workflow file")
+    elif len(parts) >= 3:
+        path_to_workflow = os.path.join('/tmp', org, repo, '/'.join(parts[2:]))
+        if not os.path.basename(path_to_workflow).endswith('.workflow'):
+            path_to_workflow = os.path.join(path_to_workflow, 'main.workflow')
+        if not os.path.isfile(path_to_workflow):
+            pu.fail("Unable to find a .workflow file")
+
+    shutil.copy(path_to_workflow, project_root)
+    pu.info("Successfully imported workflow\n".format(path_to_workflow))
+
+    with open(path_to_workflow, 'r') as fp:
+        wf = hcl.load(fp)
+    
+    action_paths = list()
+    if wf.get('action', None):
+        for _, a_block in wf['action'].items():
+            if a_block['uses'].startswith("./"):
+                action_paths.append(a_block['uses'])
+
+    action_paths = set([a.split("/")[1] for a in action_paths])
+    for a in action_paths:
+        copy_tree(os.path.join(cloned_project_dir, a), os.path.join(project_root, a))
+        pu.info("Copied {} to {}...\n".format(os.path.join(cloned_project_dir, a), project_root))
+

--- a/cli/popper/commands/cmd_add.py
+++ b/cli/popper/commands/cmd_add.py
@@ -20,21 +20,16 @@ def cli(ctx, path):
         pu.fail('Repository has not been popperized.')
         return
 
-    parts = path.split('/')
-    parts = list(filter(None, parts))
+    parts = pu.get_parts(path)
     if len(parts) < 3:
         pu.fail(
             'Required url format <url>/<user>/<repo>[/folder[/wf.workflow]]')
 
-    url, service, user, repo, _ = pu.parse('https://{}'.format(path))
-    if '@' in path:
-        branch = path.split('@')[-1]
-    else:
-        branch = 'master'
+    url, service, user, repo, _, _, version = pu.parse(path)
 
     cloned_project_dir = os.path.join("/tmp", service, user, repo)
     scm.clone(url, user, repo, os.path.dirname(
-        cloned_project_dir), branch
+        cloned_project_dir), version
     )
 
     if len(parts) == 3:

--- a/cli/popper/commands/cmd_add.py
+++ b/cli/popper/commands/cmd_add.py
@@ -47,7 +47,8 @@ def cli(ctx, path):
         else:
             pu.fail("Unable to find a .workflow file")
     elif len(parts) >= 4:
-        path_to_workflow = os.path.join(cloned_project_dir, '/'.join(parts[3:])).split("@")[0]
+        path_to_workflow = os.path.join(
+            cloned_project_dir, '/'.join(parts[3:])).split("@")[0]
         if not os.path.basename(path_to_workflow).endswith('.workflow'):
             path_to_workflow = os.path.join(path_to_workflow, 'main.workflow')
         if not os.path.isfile(path_to_workflow):

--- a/cli/popper/commands/cmd_add.py
+++ b/cli/popper/commands/cmd_add.py
@@ -8,6 +8,7 @@ import popper.scm as scm
 from popper.cli import pass_context
 from distutils.dir_util import copy_tree
 
+
 @click.command('add', short_help='Import workflow from remote repo.')
 @click.argument('path', required=True)
 @click.option(
@@ -34,7 +35,7 @@ def cli(ctx, path, branch):
 
     org = parts[0]
     repo = parts[1]
-    
+
     cloned_project_dir = os.path.join("/tmp", org, repo)
     scm.clone('https://github.com', org, repo, os.path.dirname(
         cloned_project_dir)
@@ -61,7 +62,7 @@ def cli(ctx, path, branch):
 
     with open(path_to_workflow, 'r') as fp:
         wf = hcl.load(fp)
-    
+
     action_paths = list()
     if wf.get('action', None):
         for _, a_block in wf['action'].items():
@@ -70,6 +71,7 @@ def cli(ctx, path, branch):
 
     action_paths = set([a.split("/")[1] for a in action_paths])
     for a in action_paths:
-        copy_tree(os.path.join(cloned_project_dir, a), os.path.join(project_root, a))
-        pu.info("Copied {} to {}...\n".format(os.path.join(cloned_project_dir, a), project_root))
-
+        copy_tree(os.path.join(cloned_project_dir, a),
+                  os.path.join(project_root, a))
+        pu.info("Copied {} to {}...\n".format(os.path.join(
+            cloned_project_dir, a), project_root))

--- a/cli/popper/commands/cmd_add.py
+++ b/cli/popper/commands/cmd_add.py
@@ -1,11 +1,9 @@
 import click
 import os
-import hcl
-import shutil
 import popper.utils as pu
 import popper.scm as scm
+from popper.gha import Workflow
 from popper.cli import pass_context
-from distutils.dir_util import copy_tree
 
 
 @click.command('add', short_help='Import workflow from remote repo.')
@@ -20,50 +18,4 @@ def cli(ctx, path):
         pu.fail('Repository has not been popperized.')
         return
 
-    parts = pu.get_parts(path)
-    if len(parts) < 3:
-        pu.fail(
-            'Required url format <url>/<user>/<repo>[/folder[/wf.workflow]]')
-
-    url, service, user, repo, _, _, version = pu.parse(path)
-
-    cloned_project_dir = os.path.join("/tmp", service, user, repo)
-    scm.clone(url, user, repo, os.path.dirname(
-        cloned_project_dir), version
-    )
-
-    if len(parts) == 3:
-        ptw_one = os.path.join(cloned_project_dir, "main.workflow")
-        ptw_two = os.path.join(cloned_project_dir, ".github/main.workflow")
-        if os.path.isfile(ptw_one):
-            path_to_workflow = ptw_one
-        elif os.path.isfile(ptw_two):
-            path_to_workflow = ptw_two
-        else:
-            pu.fail("Unable to find a .workflow file")
-    elif len(parts) >= 4:
-        path_to_workflow = os.path.join(
-            cloned_project_dir, '/'.join(parts[3:])).split("@")[0]
-        if not os.path.basename(path_to_workflow).endswith('.workflow'):
-            path_to_workflow = os.path.join(path_to_workflow, 'main.workflow')
-        if not os.path.isfile(path_to_workflow):
-            pu.fail("Unable to find a .workflow file")
-
-    shutil.copy(path_to_workflow, project_root)
-    pu.info("Successfully imported workflow\n".format(path_to_workflow))
-
-    with open(path_to_workflow, 'r') as fp:
-        wf = hcl.load(fp)
-
-    action_paths = list()
-    if wf.get('action', None):
-        for _, a_block in wf['action'].items():
-            if a_block['uses'].startswith("./"):
-                action_paths.append(a_block['uses'])
-
-    action_paths = set([a.split("/")[1] for a in action_paths])
-    for a in action_paths:
-        copy_tree(os.path.join(cloned_project_dir, a),
-                  os.path.join(project_root, a))
-        pu.info("Copied {} to {}...\n".format(os.path.join(
-            cloned_project_dir, a), project_root))
+    Workflow.import_from_repo(path, project_root)

--- a/cli/popper/commands/cmd_add.py
+++ b/cli/popper/commands/cmd_add.py
@@ -1,7 +1,6 @@
 import click
 import os
 import hcl
-import errno
 import shutil
 import popper.utils as pu
 import popper.scm as scm

--- a/cli/popper/commands/cmd_add.py
+++ b/cli/popper/commands/cmd_add.py
@@ -24,7 +24,7 @@ def cli(ctx, path):
     parts = list(filter(None, parts))
     if len(parts) < 3:
         pu.fail(
-            'Remote url format should be <url>/<user>/<repo>[/folder[/wf.workflow]]')
+            'Required url format <url>/<user>/<repo>[/folder[/wf.workflow]]')
 
     url, service, user, repo, _ = pu.parse('https://{}'.format(path))
     if '@' in path:

--- a/cli/popper/gha.py
+++ b/cli/popper/gha.py
@@ -319,7 +319,9 @@ class Workflow(object):
         parts = pu.get_parts(path)
         if len(parts) < 3:
             pu.fail(
-                'Required url format <url>/<user>/<repo>[/folder[/wf.workflow]]')
+                'Required url format: \
+                 <url>/<user>/<repo>[/folder[/wf.workflow]]'
+            )
 
         url, service, user, repo, _, _, version = pu.parse(path)
         cloned_project_dir = os.path.join("/tmp", service, user, repo)

--- a/cli/popper/gha.py
+++ b/cli/popper/gha.py
@@ -4,11 +4,13 @@ from concurrent.futures import ThreadPoolExecutor, as_completed
 import multiprocessing as mp
 import hcl
 import os
+import shutil
 import popper.utils as pu
 import popper.scm as scm
 from spython.main import Client
 import sys
 import popper.cli
+from distutils.dir_util import copy_tree
 
 
 class Workflow(object):
@@ -311,6 +313,56 @@ class Workflow(object):
             for n in current_stage:
                 next_stage.update(self.wf['action'][n].get('next', set()))
             current_stage = next_stage
+
+    @staticmethod
+    def import_from_repo(path, project_root):
+        parts = pu.get_parts(path)
+        if len(parts) < 3:
+            pu.fail(
+                'Required url format <url>/<user>/<repo>[/folder[/wf.workflow]]')
+
+        url, service, user, repo, _, _, version = pu.parse(path)
+        cloned_project_dir = os.path.join("/tmp", service, user, repo)
+        scm.clone(url, user, repo, os.path.dirname(
+            cloned_project_dir), version
+        )
+
+        if len(parts) == 3:
+            ptw_one = os.path.join(cloned_project_dir, "main.workflow")
+            ptw_two = os.path.join(cloned_project_dir, ".github/main.workflow")
+            if os.path.isfile(ptw_one):
+                path_to_workflow = ptw_one
+            elif os.path.isfile(ptw_two):
+                path_to_workflow = ptw_two
+            else:
+                pu.fail("Unable to find a .workflow file")
+        elif len(parts) >= 4:
+            path_to_workflow = os.path.join(
+                cloned_project_dir, '/'.join(parts[3:])).split("@")[0]
+            if not os.path.basename(path_to_workflow).endswith('.workflow'):
+                path_to_workflow = os.path.join(
+                    path_to_workflow, 'main.workflow')
+            if not os.path.isfile(path_to_workflow):
+                pu.fail("Unable to find a .workflow file")
+
+        shutil.copy(path_to_workflow, project_root)
+        pu.info("Successfully imported workflow\n".format(path_to_workflow))
+
+        with open(path_to_workflow, 'r') as fp:
+            wf = hcl.load(fp)
+
+        action_paths = list()
+        if wf.get('action', None):
+            for _, a_block in wf['action'].items():
+                if a_block['uses'].startswith("./"):
+                    action_paths.append(a_block['uses'])
+
+        action_paths = set([a.split("/")[1] for a in action_paths])
+        for a in action_paths:
+            copy_tree(os.path.join(cloned_project_dir, a),
+                      os.path.join(project_root, a))
+            pu.info("Copied {} to {}...\n".format(os.path.join(
+                cloned_project_dir, a), project_root))
 
 
 class ActionRunner(object):

--- a/cli/popper/gha.py
+++ b/cli/popper/gha.py
@@ -194,7 +194,8 @@ class Workflow(object):
                     './' in a['uses']):
                 continue
 
-            url, service, user, repo, action, action_dir, version = pu.parse(a['uses'])
+            url, service, user, repo, action, action_dir, version = pu.parse(
+                a['uses'])
 
             repo_parent_dir = os.path.join(
                 self.actions_cache_path, service, user

--- a/cli/popper/gha.py
+++ b/cli/popper/gha.py
@@ -194,18 +194,7 @@ class Workflow(object):
                     './' in a['uses']):
                 continue
 
-            url, service, user, repo, action = pu.parse(a['uses'])
-
-            if '@' in repo:
-                action_dir = '/'.join(a['uses'].split('@')[-2].split('/')[-1:])
-                version = a['uses'].split('@')[-1]
-            elif '@' in action:
-                action_dir = '/'.join(action.split('@')[-2].split('/')[-1:])
-                version = action.split('@')[-1]
-            else:
-                action_dir = '/'.join(a['uses'].split('/')[2:])
-                version = None
-            action_dir = os.path.join('./', action_dir)
+            url, service, user, repo, action, action_dir, version = pu.parse(a['uses'])
 
             repo_parent_dir = os.path.join(
                 self.actions_cache_path, service, user

--- a/cli/popper/gha.py
+++ b/cli/popper/gha.py
@@ -15,8 +15,8 @@ class Workflow(object):
     """A GHA workflow.
     """
 
-    def __init__(self, wfile, workspace, quiet, debug,
-                 dry_run, reuse, parallel):
+    def __init__(self, wfile, workspace, quiet, debug, dry_run,
+                 reuse, parallel):
         wfile = pu.find_default_wfile(wfile)
 
         with open(wfile, 'r') as fp:
@@ -194,35 +194,7 @@ class Workflow(object):
                     './' in a['uses']):
                 continue
 
-            action = None
-
-            if a['uses'].startswith('https://'):
-                a['uses'] = a['uses'][8:]
-                parts = a['uses'].split('/')
-                url = 'https://' + parts[0]
-                service = parts[0]
-                user = parts[1]
-                repo = parts[2]
-            elif a['uses'].startswith('http://'):
-                a['uses'] = a['uses'][7:]
-                parts = a['uses'].split('/')
-                url = 'http://' + parts[0]
-                service = parts[0]
-                user = parts[1]
-                repo = parts[2]
-            elif a['uses'].startswith('git@'):
-                url, rest = a['uses'].split(':')
-                user, repo = rest.split('/')
-                service = url[4:]
-            elif a['uses'].startswith('ssh://'):
-                pu.fail("The ssh protocol is not supported yet.")
-            else:
-                url = 'https://github.com'
-                service = 'github.com'
-                parts = a['uses'].split('/')
-                user = a['uses'].split('/')[0]
-                repo = a['uses'].split('/')[1]
-                action = '/'.join(a['uses'].split('/')[1:])
+            url, service, user, repo, action = pu.parse(a['uses'])
 
             if '@' in repo:
                 action_dir = '/'.join(a['uses'].split('@')[-2].split('/')[-1:])

--- a/cli/popper/gha.py
+++ b/cli/popper/gha.py
@@ -348,7 +348,7 @@ class Workflow(object):
                 pu.fail("Unable to find a .workflow file")
 
         shutil.copy(path_to_workflow, project_root)
-        pu.info("Successfully imported workflow\n".format(path_to_workflow))
+        pu.info("Successfully imported from {}\n".format(path_to_workflow))
 
         with open(path_to_workflow, 'r') as fp:
             wf = hcl.load(fp)

--- a/cli/popper/scm.py
+++ b/cli/popper/scm.py
@@ -105,14 +105,9 @@ def clone(url, org, repo, repo_parent_dir, version=None, debug=False):
     cloned_repo = git.Repo.clone_from(
         '{}{}/{}'.format(url, org, repo.split('@')[0]),
         os.path.join(repo_parent_dir, repo),
-        depth=1
+        depth=1,
+        branch=version
     )
-
-    if not version:
-        return
-
-    cloned_repo.git.checkout(version)
-
 
 def get_git_files():
     """Used to return a list of files that are being tracked by

--- a/cli/popper/utils.py
+++ b/cli/popper/utils.py
@@ -359,6 +359,7 @@ def parse(url):
         service = parts[0]
         user = parts[1]
         repo = parts[2]
+        tail = '/'.join(parts[2:])
     elif url.startswith('http://'):
         url = url[7:]
         parts = url.split('/')
@@ -366,9 +367,13 @@ def parse(url):
         service = parts[0]
         user = parts[1]
         repo = parts[2]
+        tail = '/'.join(parts[2:])
     elif url.startswith('git@'):
         service_url, rest = url.split(':')
-        user, repo = rest.split('/')
+        parts = rest.split('/')
+        user = parts[0]
+        repo = parts[1]
+        tail = '/'.join(parts[1:])
         service = service_url[4:]
     elif url.startswith('ssh://'):
         pu.fail("The ssh protocol is not supported yet.")
@@ -376,7 +381,34 @@ def parse(url):
         service_url = 'https://github.com'
         service = 'github.com'
         parts = url.split('/')
-        user = url.split('/')[0]
-        repo = url.split('/')[1]
+        user = parts[0]
+        repo = parts[1]
+        tail = '/'.join(parts[1:])
         action = '/'.join(url.split('/')[1:])
-    return (service_url, service, user, repo, action)
+
+    if '@' in tail:
+        action_dir = '/'.join(url.split('@')[-2].split('/')[-1:])
+        version = url.split('@')[-1]
+    elif '@' in action:
+        action_dir = '/'.join(action.split('@')[-2].split('/')[-1:])
+        version = action.split('@')[-1]
+    else:
+        action_dir = '/'.join(url.split('/')[2:])
+        version = None
+    action_dir = os.path.join('./', action_dir)
+
+    return (service_url, service, user, repo, action, action_dir, version)
+
+def get_parts(url):
+    if url.startswith('https://'):
+        parts = url[8:].split('/')
+    elif url.startswith('http://'):
+        parts = url[7:].split('/')
+    elif url.startswith('git@'):
+        service_url, rest = url.split(':')
+        parts = ['github.com'] + rest.split('/')
+    elif url.startswith('ssh://'):
+        pu.fail('The ssh protocol is not supported yet.')
+    else:
+        parts = ['github.com'] + url.split('/')
+    return parts

--- a/cli/popper/utils.py
+++ b/cli/popper/utils.py
@@ -399,6 +399,7 @@ def parse(url):
 
     return (service_url, service, user, repo, action, action_dir, version)
 
+
 def get_parts(url):
     if url.startswith('https://'):
         parts = url[8:].split('/')

--- a/cli/popper/utils.py
+++ b/cli/popper/utils.py
@@ -344,3 +344,38 @@ def find_recursive_wfile():
                 wfile = os.path.abspath(wfile)
                 wfile_list.append(wfile)
     return wfile_list
+
+def parse(url):
+    service_url = None
+    service = None
+    user = None
+    repo = None
+    action = None
+    if url.startswith('https://'):
+        url = url[8:]
+        parts = url.split('/')
+        service_url = 'https://' + parts[0]
+        service = parts[0]
+        user = parts[1]
+        repo = parts[2]
+    elif url.startswith('http://'):
+        url = url[7:]
+        parts = url.split('/')
+        service_url = 'http://' + parts[0]
+        service = parts[0]
+        user = parts[1]
+        repo = parts[2]
+    elif url.startswith('git@'):
+        service_url, rest = url.split(':')
+        user, repo = rest.split('/')
+        service = service_url[4:]
+    elif url.startswith('ssh://'):
+        pu.fail("The ssh protocol is not supported yet.")
+    else:
+        service_url = 'https://github.com'
+        service = 'github.com'
+        parts = url.split('/')
+        user = url.split('/')[0]
+        repo = url.split('/')[1]
+        action = '/'.join(url.split('/')[1:])
+    return (service_url, service, user, repo, action)

--- a/cli/popper/utils.py
+++ b/cli/popper/utils.py
@@ -345,6 +345,7 @@ def find_recursive_wfile():
                 wfile_list.append(wfile)
     return wfile_list
 
+
 def parse(url):
     service_url = None
     service = None


### PR DESCRIPTION
Implements the `popper add` command. On doing `popper add cplee/github-actions-demo` , the repository is cloned, the `main.workflow` file searched, scanned, copied to `project_root` and then the toplevel folder of local actions are also copied which are identified by parsing the workflow.