### PR TITLE
Fixes add test

### DIFF
--- a/ci/test/add
+++ b/ci/test/add
@@ -25,13 +25,13 @@ test -f /tmp/mypaper/main.workflow
 rm -rf /tmp/mypaper/.github
 rm /tmp/mypaper/main.workflow
 
-popper add cplee/github-actions-demo@master
+popper add cplee/github-actions-demo/.github@master
 test -f /tmp/mypaper/.github/actions/jshint/Dockerfile
 test -f /tmp/mypaper/main.workflow
 rm -rf /tmp/mypaper/.github
 rm /tmp/mypaper/main.workflow
 
-popper add cplee/github-actions-demo@master
+popper add cplee/github-actions-demo/.github/main.workflow@master
 test -f /tmp/mypaper/.github/actions/jshint/Dockerfile
 test -f /tmp/mypaper/main.workflow
 rm -rf /tmp/mypaper/.github


### PR DESCRIPTION
@ivotron  Somehow some redundant tests crept into `ci/test/add`. Fixing that in this PR. Sorry for not noticing it before.