### PR TITLE
Fixes for the unit test failing

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,8 @@ python:
 env:
 - RUNTIME=singularity POPPER_TEST_MODE=with-git
 - RUNTIME=docker POPPER_TEST_MODE=without-git
+- RUNTIME=docker POPPER_TEST_MODE=with-git
+- RUNTIME=singularity POPPER_TEST_MODE=without-git
 services: docker
 before_install:
 - ci/scripts/install_scripts.sh

--- a/cli/test/test_scm.py
+++ b/cli/test/test_scm.py
@@ -59,8 +59,14 @@ class TestScm(unittest.TestCase):
     def test_get_remote_url(self):
         url = scm.get_remote_url()
         if self.with_git:
-            self.assertEqual(
-                url, 'https://github.com/popperized/github-actions-demo')
+            auth_token = os.getenv('GITHUB_API_TOKEN')
+            if(auth_token is None):
+                self.assertEqual(
+                    url, 'https://github.com/popperized/github-actions-demo')
+            else:
+                self.assertEqual(
+                    url[:8]+url[url.find('@')+1:],
+                    'https://github.com/popperized/github-actions-demo')
         else:
             self.assertEqual(url, '')
 


### PR DESCRIPTION
Fixes for the unit tests that were failing due to support for OAUTH GitHub token to reference private repositories in action.
