### PR TITLE
fix f string in codebase #764

### DIFF
--- a/cli/popper/commands/cmd_ci.py
+++ b/cli/popper/commands/cmd_ci.py
@@ -129,4 +129,4 @@ def cli(ctx, service, wfile):
         with open(ci_file, 'w') as f:
             f.write(ci_file_content.format(wfile))
 
-    log.info('Wrote {} configuration successfully.'.format(service))
+    log.info(f'Wrote {service} configuration successfully.')

--- a/cli/popper/commands/cmd_dot.py
+++ b/cli/popper/commands/cmd_dot.py
@@ -58,10 +58,10 @@ def cli(ctx, wfile, skip, colors):
 
         """
         for n in children:
-            edge = '  "{}" -> "{}";\n'.format(parent, n)
+            edge = f'  "{parent}" -> "{n}";\n'
             if edge in stage_edges:
                 continue
-            dot_str += edge + '  "{}" [{}];\n'.format(n, node_attrs)
+            dot_str += edge + f'  "{n}" [{node_attrs}];\n'
 
             stage_edges.add(edge)
 
@@ -81,7 +81,7 @@ def cli(ctx, wfile, skip, colors):
     wf_attr = node_attrs.format(',rounded', ',color=red' if colors else '')
     act_attr = node_attrs.format('', ',color=cyan' if colors else '')
     dot_str = add_to_graph("", wf, wf.name, wf.root, act_attr, set())
-    dot_str += '  "{}" [{}];\n'.format(wf.name, wf_attr)
+    dot_str += f'  "{wf.name}" [{wf_attr}];\n'
     log.info(
         "digraph G { graph [bgcolor=transparent];\n" + dot_str + "}\n"
     )

--- a/cli/popper/commands/cmd_version.py
+++ b/cli/popper/commands/cmd_version.py
@@ -18,4 +18,4 @@ def cli(ctx):
     # Returns:
     #   None
 
-    log.info('Popper version {}'.format(popper_version))
+    log.info(f'Popper version {popper_version}')

--- a/cli/popper/log.py
+++ b/cli/popper/log.py
@@ -34,12 +34,12 @@ class PopperFormatter(logging.Formatter):
     BOLD_RED = '[01;31m'
 
     log_format = {
-        'DEBUG':       '{}%(levelname)s: %(msg)s {}'.format(BOLD_CYAN, RESET),
+        'DEBUG':       f'{BOLD_CYAN}%(levelname)s: %(msg)s {RESET}',
         'STEP_INFO': '%(msg)s',
         'INFO':        '%(msg)s',
-        'WARNING':     '{}%(levelname)s: %(msg)s{}'.format(BOLD_YELLOW, RESET),
-        'ERROR':       '{}%(levelname)s: %(msg)s{}'.format(BOLD_RED, RESET),
-        'CRITICAL':    '{}%(levelname)s: %(msg)s{}'.format(BOLD_RED, RESET)
+        'WARNING':     f'{BOLD_YELLOW}%(levelname)s: %(msg)s{RESET}',
+        'ERROR':       f'{BOLD_RED}%(levelname)s: %(msg)s{RESET}',
+        'CRITICAL':    f'{BOLD_RED}%(levelname)s: %(msg)s{RESET}'
     }
 
     log_format_no_colors = {

--- a/cli/popper/runner.py
+++ b/cli/popper/runner.py
@@ -110,10 +110,10 @@ class WorkflowRunner(object):
             for s in a.get('secrets', []):
                 if s not in os.environ:
                     if os.environ.get('CI', '') == 'true':
-                        log.fail('Secret {} not defined'.format(s))
+                        log.fail(f'Secret {s} not defined')
                     else:
                         val = getpass.getpass(
-                            'Enter the value for {} : '.format(s))
+                            f'Enter the value for {s} : ')
                         os.environ[s] = val
 
     @staticmethod
@@ -159,12 +159,12 @@ class WorkflowRunner(object):
                 log.info('[popper] Cloning step repositories')
                 infoed = True
 
-            if '{}/{}'.format(user, repo) in cloned:
+            if f'{user}/{repo}' in cloned:
                 continue
 
-            log.info('[popper] - {}/{}/{}@{}'.format(url, user, repo, version))
+            log.info(f'[popper] - {url}/{user}/{repo}@{version}')
             scm.clone(url, user, repo, repo_dir, version)
-            cloned.add('{}/{}'.format(user, repo))
+            cloned.add(f'{user}/{repo}')
 
     def run(self, wf):
         """Run the given workflow.

--- a/cli/popper/scm.py
+++ b/cli/popper/scm.py
@@ -67,8 +67,8 @@ def get_sha(repo):
             return repo.git.rev_parse(repo.head.object.hexsha, short=True)
         except ValueError as e:
             log.debug(e)
-            log.fail('Could not obtain revision of repository located at {}'
-                     .format(get_project_root_folder(repo)))
+            log.fail(f'Could not obtain revision of repository located at {get_project_root_folder(repo)}'
+                    )
     else:
         return 'na'
 
@@ -143,7 +143,7 @@ def clone(url, org, repo, repo_dir, version=None):
             # The length of protocol is 8 in case of https://
             url = url[:8]+auth_token+'@'+url[8:]
 
-        repo_url = '{}{}/{}'.format(url, org, repo)
+        repo_url = f'{url}{org}/{repo}'
         cloned_repo = git.Repo.clone_from(repo_url, repo_dir)
 
     cloned_repo.git.checkout(get_default_branch(cloned_repo))
@@ -193,12 +193,12 @@ def parse(url):
 
     service_url = protocol + service
 
-    log.debug('parse("{}"):'.format(url))
-    log.debug('  service_url: {}'.format(service_url))
-    log.debug('  service: {}'.format(service))
-    log.debug('  user: {}'.format(user))
-    log.debug('  repo: {}'.format(repo))
-    log.debug('  step_dir: {}'.format(step_dir))
-    log.debug('  version: {}'.format(version))
+    log.debug(f'parse("{url}"):')
+    log.debug(f'  service_url: {service_url}')
+    log.debug(f'  service: {service}')
+    log.debug(f'  user: {user}')
+    log.debug(f'  repo: {repo}')
+    log.debug(f'  step_dir: {step_dir}')
+    log.debug(f'  version: {version}')
 
     return service_url, service, user, repo, step_dir, version

--- a/cli/popper/utils.py
+++ b/cli/popper/utils.py
@@ -96,7 +96,7 @@ def sanitized_name(name, wid=''):
     Returns:
       str: The sanitize step name.
     """
-    return "popper_{}_{}".format(re.sub('[^a-zA-Z0-9_.-]', '_', name), wid)
+    return f"popper_{re.sub('[^a-zA-Z0-9_.-]', '_', name)}_{wid}"
 
 
 def of_type(param, valid_types):
@@ -173,7 +173,7 @@ def load_config_file(config_file):
       dict: Engine configuration.
     """
     if not os.path.exists(config_file):
-        log.fail('File {} was not found.'.format(config_file))
+        log.fail(f'File {config_file} was not found.')
 
     if not config_file.endswith('.py'):
         log.fail('Configuration file must be a python source file.')


### PR DESCRIPTION
The refactoring took a lot of the format method away from the repo. I fixed the remaining format usage. We're now covered with Python >3.6x syntax.